### PR TITLE
Easy config : replace string with enum

### DIFF
--- a/lib/easy-config-bundle/src/Controller/Admin/EasyConfigCrudController.php
+++ b/lib/easy-config-bundle/src/Controller/Admin/EasyConfigCrudController.php
@@ -2,6 +2,7 @@
 
 namespace Adeliom\EasyConfigBundle\Controller\Admin;
 
+use Adeliom\EasyConfigBundle\Enum\EasyConfigType;
 use Adeliom\EasyFieldsBundle\Admin\Field\ChoiceMaskField;
 use Adeliom\EasyMediaBundle\Admin\Field\EasyMediaField;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
@@ -54,6 +55,26 @@ abstract class EasyConfigCrudController extends AbstractCrudController
         return $crud;
     }
 
+    protected function getAvailableTypes() : array
+    {
+        $types = EasyConfigType::getValues();
+        $choices = [];
+        foreach ($types as $type) {
+            $choices['easy_config.types.'. $type] = $type;
+        }
+        return $choices;
+    }
+
+    protected function getFieldMap() : array
+    {
+        $types = EasyConfigType::getValues();
+        $choices = [];
+        foreach ($types as $type) {
+            $choices[$type] = [$type];
+        }
+        return $choices;
+    }
+
     public function configureFilters(Filters $filters): Filters
     {
         $filters = parent::configureFilters($filters);
@@ -62,22 +83,7 @@ abstract class EasyConfigCrudController extends AbstractCrudController
         $filters->add(TextFilter::new('name', 'easy_config.form.name'));
         $filters->add(ChoiceFilter::new('type', 'easy_config.form.type')
             ->setFormTypeOption('translation_domain', 'messages')
-            ->setChoices([
-                'easy_config.types.code' => 'code',
-                'easy_config.types.email' => 'email',
-                'easy_config.types.number' => 'number',
-                'easy_config.types.json' => 'json',
-                'easy_config.types.text' => 'text',
-                'easy_config.types.textarea' => 'textarea',
-                'easy_config.types.wysiwyg' => 'wysiwyg',
-                'easy_config.types.boolean' => 'boolean',
-                'easy_config.types.image' => 'image',
-                'easy_config.types.file' => 'file',
-                'easy_config.types.color' => 'color',
-                'easy_config.types.date' => 'date',
-                'easy_config.types.time' => 'time',
-                'easy_config.types.datetime' => 'datetime',
-            ]));
+            ->setChoices($this->getAvailableTypes()));
 
         return $filters;
     }
@@ -111,123 +117,93 @@ abstract class EasyConfigCrudController extends AbstractCrudController
         yield TextareaField::new('description', 'easy_config.form.description');
         yield ChoiceMaskField::new('type', 'easy_config.form.type')
             ->setFormTypeOption('disabled', Crud::PAGE_EDIT == $pageName)
-            ->setChoices([
-                'easy_config.types.code' => 'code',
-                'easy_config.types.email' => 'email',
-                'easy_config.types.number' => 'number',
-                'easy_config.types.json' => 'json',
-                'easy_config.types.text' => 'text',
-                'easy_config.types.textarea' => 'textarea',
-                'easy_config.types.wysiwyg' => 'wysiwyg',
-                'easy_config.types.boolean' => 'boolean',
-                'easy_config.types.image' => 'image',
-                'easy_config.types.file' => 'file',
-                'easy_config.types.color' => 'color',
-                'easy_config.types.date' => 'date',
-                'easy_config.types.time' => 'time',
-                'easy_config.types.datetime' => 'datetime',
-            ])
-            ->setMap([
-                'code' => ['code'],
-                'number' => ['number'],
-                'email' => ['email'],
-                'json' => ['json'],
-                'text' => ['text'],
-                'boolean' => ['boolean'],
-                'wysiwyg' => ['wysiwyg'],
-                'textarea' => ['textarea'],
-                'file' => ['file'],
-                'image' => ['image'],
-                'color' => ['color'],
-                'date' => ['date'],
-                'time' => ['time'],
-                'datetime' => ['datetime'],
-            ])
+            ->setChoices($this->getAvailableTypes())
+            ->setMap($this->getFieldMap())
             ->renderAsBadges()
             ->setRequired(true)
             ->setColumns('col-12 col-sm-6');
 
         if ($config) {
-            if (self::isEditable('code', $config, $pageName)) {
-                yield CodeEditorField::new('code', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::CODE, $config, $pageName)) {
+                yield CodeEditorField::new(EasyConfigType::CODE, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('image', $config, $pageName) && class_exists(\Adeliom\EasyMediaBundle\Form\EasyMediaType::class)) {
-                yield EasyMediaField::new('image', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::IMAGE, $config, $pageName) && class_exists(\Adeliom\EasyMediaBundle\Form\EasyMediaType::class)) {
+                yield EasyMediaField::new(EasyConfigType::IMAGE, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setFormTypeOption('restrictions_uploadTypes', ['image/*'])
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('file', $config, $pageName) && class_exists(\Adeliom\EasyMediaBundle\Form\EasyMediaType::class)) {
-                yield EasyMediaField::new('file', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::FILE, $config, $pageName) && class_exists(\Adeliom\EasyMediaBundle\Form\EasyMediaType::class)) {
+                yield EasyMediaField::new(EasyConfigType::FILE, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('color', $config, $pageName)) {
-                yield ColorField::new('color', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::COLOR, $config, $pageName)) {
+                yield ColorField::new(EasyConfigType::COLOR, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('date', $config, $pageName)) {
-                yield DateField::new('date', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::DATE, $config, $pageName)) {
+                yield DateField::new(EasyConfigType::DATE, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('time', $config, $pageName)) {
-                yield TimeField::new('time', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::TIME, $config, $pageName)) {
+                yield TimeField::new(EasyConfigType::TIME, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('datetime', $config, $pageName)) {
-                yield DateTimeField::new('datetime', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::DATETIME, $config, $pageName)) {
+                yield DateTimeField::new(EasyConfigType::DATETIME, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('email', $config, $pageName)) {
-                yield EmailField::new('email', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::EMAIL, $config, $pageName)) {
+                yield EmailField::new(EasyConfigType::EMAIL, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('number', $config, $pageName)) {
-                yield NumberField::new('number', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::NUMBER, $config, $pageName)) {
+                yield NumberField::new(EasyConfigType::NUMBER, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('json', $config, $pageName)) {
-                yield CodeEditorField::new('json', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::JSON, $config, $pageName)) {
+                yield CodeEditorField::new(EasyConfigType::JSON, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('text', $config, $pageName)) {
-                yield TextField::new('text', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::TEXT, $config, $pageName)) {
+                yield TextField::new(EasyConfigType::TEXT, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('wysiwyg', $config, $pageName) && class_exists(\FOS\CKEditorBundle\Form\Type\CKEditorType::class)) {
-                yield TextareaField::new('wysiwyg', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::WYSIWYG, $config, $pageName) && class_exists(\FOS\CKEditorBundle\Form\Type\CKEditorType::class)) {
+                yield TextareaField::new(EasyConfigType::WYSIWYG, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->renderAsHtml()
@@ -235,15 +211,15 @@ abstract class EasyConfigCrudController extends AbstractCrudController
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('textarea', $config, $pageName)) {
-                yield TextareaField::new('textarea', 'easy_config.form.value')
+            if (self::isEditable(EasyConfigType::TEXTAREA, $config, $pageName)) {
+                yield TextareaField::new(EasyConfigType::TEXTAREA, 'easy_config.form.value')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');
             }
 
-            if (self::isEditable('boolean', $config, $pageName)) {
-                yield BooleanField::new('boolean', 'easy_config.form.value_bool')
+            if (self::isEditable(EasyConfigType::BOOLEAN, $config, $pageName)) {
+                yield BooleanField::new(EasyConfigType::BOOLEAN, 'easy_config.form.value_bool')
                     ->setVirtual(true)
                     ->hideOnIndex()
                     ->setColumns('col-12');

--- a/lib/easy-config-bundle/src/Entity/Config.php
+++ b/lib/easy-config-bundle/src/Entity/Config.php
@@ -3,6 +3,7 @@
 namespace Adeliom\EasyConfigBundle\Entity;
 
 use Adeliom\EasyCommonBundle\Traits\EntityIdTrait;
+use Adeliom\EasyConfigBundle\Enum\EasyConfigType;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
@@ -129,13 +130,13 @@ class Config
     {
         if ($this->type == $name) {
             switch ($name) {
-                case 'date':
+                case EasyConfigType::DATE:
                     return $this->getDate();
-                case 'time':
+                case EasyConfigType::TIME:
                     return $this->getTime();
-                case 'datetime':
+                case EasyConfigType::DATETIME:
                     return $this->getDatetime();
-                case 'boolean':
+                case EasyConfigType::BOOLEAN:
                     return $this->getBoolean();
                 default:
                     return $this->value;
@@ -161,7 +162,7 @@ class Config
 
     public function getBoolean()
     {
-        if ('boolean' == $this->type) {
+        if (EasyConfigType::BOOLEAN == $this->type) {
             return (bool) $this->value;
         }
 
@@ -170,7 +171,7 @@ class Config
 
     public function setDate(?\DateTime $date)
     {
-        if ('date' == $this->type && $date) {
+        if (EasyConfigType::DATE == $this->type && $date) {
             $this->value = $date->format('Y-m-d');
         }
 
@@ -179,7 +180,7 @@ class Config
 
     public function getDate()
     {
-        if ('date' == $this->type) {
+        if (EasyConfigType::DATE == $this->type) {
             try {
                 return new \DateTime($this->value);
             } catch (\Exception) {
@@ -192,7 +193,7 @@ class Config
 
     public function setTime(?\DateTime $date)
     {
-        if ('time' == $this->type) {
+        if (EasyConfigType::TIME == $this->type) {
             $this->value = $date->format('H:i:s');
         }
 
@@ -201,7 +202,7 @@ class Config
 
     public function getTime()
     {
-        if ('time' == $this->type) {
+        if (EasyConfigType::TIME == $this->type) {
             try {
                 return new \DateTime($this->value);
             } catch (\Exception) {
@@ -214,7 +215,7 @@ class Config
 
     public function setDatetime(?\DateTime $date)
     {
-        if ('datetime' == $this->type && $date) {
+        if (EasyConfigType::DATETIME == $this->type && $date) {
             $this->value = $date->format('Y-m-d H:i:s');
         }
 
@@ -223,7 +224,7 @@ class Config
 
     public function getDatetime()
     {
-        if ('datetime' == $this->type) {
+        if (EasyConfigType::DATETIME == $this->type) {
             try {
                 return new \DateTime($this->value);
             } catch (\Exception) {

--- a/lib/easy-config-bundle/src/Enum/EasyConfigType.php
+++ b/lib/easy-config-bundle/src/Enum/EasyConfigType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Adeliom\EasyConfigBundle\Enum;
+
+use ReflectionClass;
+
+//@TODO switch to enum after php 8.1 migration
+class EasyConfigType
+{
+    public const CODE = 'code';
+    public const EMAIL = 'email';
+    public const NUMBER = 'number';
+    public const JSON = 'json';
+    public const TEXT = 'text';
+    public const TEXTAREA = 'textarea';
+    public const WYSIWYG = 'wysiwyg';
+    public const BOOLEAN = 'boolean';
+    public const IMAGE = 'image';
+    public const FILE = 'file';
+    public const COLOR = 'color';
+    public const DATE = 'date';
+    public const TIME = 'time';
+    public const DATETIME = 'datetime';
+
+    static function getValues(): array
+    {
+        $oClass = new ReflectionClass(__CLASS__);
+        return $oClass->getConstants();
+    }
+}

--- a/lib/easy-config-bundle/src/Twig/EasyConfigExtension.php
+++ b/lib/easy-config-bundle/src/Twig/EasyConfigExtension.php
@@ -2,6 +2,7 @@
 
 namespace Adeliom\EasyConfigBundle\Twig;
 
+use Adeliom\EasyConfigBundle\Enum\EasyConfigType;
 use Adeliom\EasyConfigBundle\Repository\ConfigRepository;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
@@ -30,9 +31,9 @@ class EasyConfigExtension extends AbstractExtension
             if ($directValue) {
                 $value = $config->{$config->getType()};
 
-                if (in_array($config->getType(), ['code', 'wysiwyg', 'textarea', 'text'])) {
+                if (in_array($config->getType(), [EasyConfigType::CODE, EasyConfigType::WYSIWYG, EasyConfigType::TEXTAREA, EasyConfigType::TEXT])) {
                     return new Markup($value, 'UTF-8');
-                } elseif ('json' == $config->getType()) {
+                } elseif (EasyConfigType::JSON == $config->getType()) {
                     return json_decode((string) $value, true, 512, JSON_THROW_ON_ERROR);
                 } else {
                     return $value;


### PR DESCRIPTION
Easy config bundle :
- Avoid using string for config type by creating a enum class (to stay compatible with 8.0)