### PR TITLE
feat(page): add trailing slash boolean parameter to easy page config

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -20,6 +20,10 @@ services:
     hogfrom:
       - appserver
 
+  database:
+    run_as_root:
+      - mysql -uroot -e "CREATE DATABASE IF NOT EXISTS lamp_test; GRANT ALL PRIVILEGES ON lamp_test.* TO 'lamp'@'%'; FLUSH PRIVILEGES;"
+
   phpmyadmin:
     scanner: false
     type: phpmyadmin

--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ Execute follow outside your container (php 8.0 is required) and run
 If dry run execution is successfull run :
 
 ``vendor/bin/monorepo-builder release patch``
+
+### PHPUnit tests
+
+Read https://github.com/symplify/monorepo-builder
+
+https://github.com/sym
+
+```
+lando console d:m:m --env=test -n
+lando console doc:fixtures:load --env=test -n
+lando composer unit-tests
+``

--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,9 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
+        ],
+        "unit-tests": [
+            "php bin/phpunit"
         ]
     },
     "extra": {

--- a/config/packages/easy_page.yaml
+++ b/config/packages/easy_page.yaml
@@ -2,6 +2,7 @@ easy_page:
   page_class: App\Entity\EasyPage\Page
   page_repository: App\Repository\EasyPage\PageRepository
   page_controller: App\Controller\EasyPage\PageController
+  trailing_slash: true
   layouts:
     front:
       resource: '@EasyPage/default_layout.html.twig'

--- a/lib/easy-page-bundle/src/Controller/PageController.php
+++ b/lib/easy-page-bundle/src/Controller/PageController.php
@@ -60,7 +60,7 @@ class PageController extends AbstractPageController
         if ($slugs && $currentPage->isHomepage()) {
             $params = ['slugs' => ''];
 
-            return $this->redirect($this->generateUrl('easy_page_index', $params));
+            return $this->redirect(rtrim($this->generateUrl('easy_page_index', $params), '/') . '/');
         }
 
         if ($currentPage->getTemplate() && $this->twig->getLoader()->exists('@EasyPage/front/pages/'.$currentPage->getTemplate().'.html.twig')) {

--- a/lib/easy-page-bundle/src/DependencyInjection/Configuration.php
+++ b/lib/easy-page-bundle/src/DependencyInjection/Configuration.php
@@ -63,6 +63,15 @@ class Configuration implements ConfigurationInterface
                         })
                     ->end()
                 ->end()
+                ->scalarNode('trailing_slash')
+                    ->defaultValue(false)
+                    ->validate()
+                        ->ifString()
+                        ->then(function ($value) {
+                            return (bool) $value;
+                        })
+                    ->end()
+                ->end()
                 ->arrayNode('layouts')
                     ->defaultValue([
                         'front' => [

--- a/lib/easy-page-bundle/src/EventListener/LayoutsListener.php
+++ b/lib/easy-page-bundle/src/EventListener/LayoutsListener.php
@@ -98,7 +98,7 @@ class LayoutsListener implements EventSubscriberInterface
         $pages = $this->pageRepository->findFrontPages($slugsArray, $event->getRequest()->getHost(), $event->getRequest()->getLocale());
         $tree = [];
         $homePageInSlugsArray = false;
-        // TODO : how to now if home page has an url https://www.mysite.com/home or if
+        // TODO : how to know if home page has an url https://www.mysite.com/home or if
         // it https://www.mysite.com/ (by default consider home page has no slug
         foreach (array_reverse($pages) as $page) {
             $current = $page;

--- a/lib/easy-page-bundle/src/Resources/config/services.yaml
+++ b/lib/easy-page-bundle/src/Resources/config/services.yaml
@@ -15,6 +15,7 @@ services:
             - '%easy_page.page_controller%'
             - '%easy_page.page_class%'
             - '@easy_page.repository'
+            - '%easy_page.trailing_slash%'
             - '%kernel.environment%'
         tags: [ routing.loader ]
 

--- a/lib/easy-page-bundle/src/Routing/PageLoader.php
+++ b/lib/easy-page-bundle/src/Routing/PageLoader.php
@@ -11,16 +11,23 @@ class PageLoader extends Loader
 {
     private bool $isLoaded = false;
 
-    public function __construct(/**
+    public function __construct(
+        /**
          * @readonly
          */
-        private string $controller, /**
+        private string $controller,
+        /**
          * @readonly
          */
-        private string $entity, /**
+        private string $entity,
+        /**
          * @readonly
          */
         private PageRepository $repository,
+        /**
+         * @readonly
+         */
+        private bool $trailingSlash,
         string $env = null
     ) {
         parent::__construct($env);
@@ -52,13 +59,13 @@ class PageLoader extends Loader
         }*/
 
         // prepare a new route
-        $path = '/{slugs}';
+        $path = '/{slugs}' . ($this->trailingSlash ? '/' : '');
         $defaults = [
-            '_controller' => $this->controller.'::index',
+            '_controller' => $this->controller . '::index',
             'slugs' => '',
         ];
         $requirements = [
-            'slugs' => "([a-zA-Z0-9_-]+\/?)*",
+            'slugs' => "([a-zA-Z0-9_-]+\/?)*" . ($this->trailingSlash ? '|^$' : ''), // if trailing slash, then also allow for empty path (homepage)
         ];
         $route = new Route($path, $defaults, $requirements, [], '', [], [], "request.attributes.has('_easy_page_pages')");
 

--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -8,6 +8,6 @@ use Symfony\Contracts\EventDispatcher\Event;
 class BreadcrumbListener {
     public function __invoke(Event $event): void
     {
-        dump($event);
+//        dump($event);
     }
 }

--- a/tests/PageTrailingSlashTest.php
+++ b/tests/PageTrailingSlashTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class PageTrailingSlashTest extends WebTestCase
+{
+    /**
+     * @dataProvider pageProvider
+     */
+    public function testPageResponseIsSuccessful(string $url): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(true);
+        $client->request('GET', $url);
+        self::assertResponseIsSuccessful('Erreur sur l\'URL . ' . $url);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function pageProvider(): array
+    {
+        return [
+            ['https://easyadmin-sandbox.lndo.site/'],
+            ['https://easyadmin-sandbox.lndo.site/page-daccueil/'],
+            ['https://easyadmin-sandbox.lndo.site/child-page/'],
+//            ['https://easyadmin-sandbox.lndo.site/test-page/'],
+        ];
+    }
+}

--- a/tests/TestTrailingSlashFalseKernel.php
+++ b/tests/TestTrailingSlashFalseKernel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Tests\TestKernels;
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class TestTrailingSlashFalseKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        parent::configureContainer($container);
+        $container->import(__DIR__.'/../config/easy_page_trailing_slash_false.yaml');
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        parent::configureRoutes($routes);
+    }
+}

--- a/tests/TestTrailingSlashTrueKernel.php
+++ b/tests/TestTrailingSlashTrueKernel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Tests\TestKernels;
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+class TestTrailingSlashTrueKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        parent::configureContainer($container);
+        $container->import(__DIR__.'/../config/easy_page_trailing_slash_true.yaml');
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        parent::configureRoutes($routes);
+    }
+}


### PR DESCRIPTION
Pour tester 👍 

lancer 
```bash
lando composer unit-tests
```
Modifier d'abord les fichiers suivants :

`.env`
```
KERNEL_CLASS='App\Kernel'
```

`config/package/easy_page.yaml`
```
  page_controller: App\Controller\EasyPage\PageController
  trailing_slash: true
```

`config/package/framework.yaml`
```
framework:
    test: true
```

`phpunit.xml.dist`
```
        <server name="APP_ENV" value="dev" force="true" />
```