### PR TITLE
feat(fields): add support for counter fields

### DIFF
--- a/lib/easy-seo-bundle/src/Admin/Field/SEOFieldCount.php
+++ b/lib/easy-seo-bundle/src/Admin/Field/SEOFieldCount.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\EasySeoBundle\Admin\Field;
+
+use Adeliom\EasySeoBundle\Form\SeoCountType;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Field\FieldTrait;
+
+final class SEOFieldCount implements FieldInterface
+{
+    use FieldTrait;
+
+    /**
+     * @param string|false|null $label
+     */
+    public static function new(string $propertyName, $label = false): self
+    {
+        return (new self())
+            ->setProperty($propertyName)
+            ->setLabel($label)
+            ->hideOnIndex()
+            ->setTemplatePath('@EasySeo/seo-detail.html.twig')
+            ->setFormType(SeoCountType::class)
+            ->addCssFiles('bundles/easyseo/seo-form.css')
+            ->addCssClass('field-seo')
+            ->setDefaultColumns('') // this is set dynamically in the field configurator
+        ;
+    }
+}

--- a/lib/easy-seo-bundle/src/Form/Fields/TextCounterType.php
+++ b/lib/easy-seo-bundle/src/Form/Fields/TextCounterType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\EasySeoBundle\Form\Fields;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class TextCounterType extends TextType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'text_counter';
+    }
+
+    public function getParent(): string
+    {
+        return TextType::class;
+    }
+
+    public function getWidgetPrefix(): string
+    {
+        return 'text_counter';
+    }
+}

--- a/lib/easy-seo-bundle/src/Form/Fields/TextareaCounterType.php
+++ b/lib/easy-seo-bundle/src/Form/Fields/TextareaCounterType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adeliom\EasySeoBundle\Form\Fields;
+
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+class TextareaCounterType extends TextareaType
+{
+    public function getBlockPrefix(): string
+    {
+        return 'textarea_counter';
+    }
+
+    public function getParent(): string
+    {
+        return TextareaType::class;
+    }
+
+    public function getWidgetPrefix(): string
+    {
+        return 'textarea_counter';
+    }
+}

--- a/lib/easy-seo-bundle/src/Form/SeoCountType.php
+++ b/lib/easy-seo-bundle/src/Form/SeoCountType.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Adeliom\EasySeoBundle\Form;
+
+use Adeliom\EasyMediaBundle\Form\EasyMediaType;
+use Adeliom\EasySeoBundle\Entity\SEO;
+use Adeliom\EasySeoBundle\Form\Fields\TextareaCounterType;
+use Adeliom\EasySeoBundle\Form\Fields\TextCounterType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SeoCountType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('title', TextCounterType::class, [
+                'label' => 'easy.seo.admin.field.title',
+            ])
+            ->add('cover', EasyMediaType::class, [
+                'label' => 'easy.seo.admin.field.cover',
+                'restrictions_uploadTypes' => ['image/*'],
+            ])
+            ->add('cannonical', UrlType::class, [
+                'label' => 'easy.seo.admin.field.cannonical',
+            ])
+            ->add('description', TextareaCounterType::class, [
+                'label' => 'easy.seo.admin.field.description',
+            ])
+            ->add('keywords', TextType::class, [
+                'label' => 'easy.seo.admin.field.keywords',
+            ])
+            ->add('key', TextType::class, [
+                'label' => 'easy.seo.admin.field.key',
+            ])
+            ->add('robots', ChoiceType::class, [
+                'label' => 'easy.seo.admin.field.robots',
+                'multiple' => 'true',
+                'attr' => [
+                    'data-ea-widget' => 'ea-autocomplete',
+                ],
+                'choices' => [
+                    'noindex' => 'noindex',
+                    'nofollow' => 'nofollow',
+                    'noarchive' => 'noarchive',
+                    'nosnippet' => 'nosnippet',
+                    'notranslate' => 'notranslate',
+                    'noimageindex' => 'noimageindex',
+                ],
+            ])
+            ->add('sitemap', CheckboxType::class, [
+                'label' => 'easy.seo.admin.field.sitemap',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label' => false,
+            'data_class' => SEO::class,
+        ]);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'easy_seo';
+    }
+}

--- a/lib/easy-seo-bundle/src/Resources/views/fields/text_counter_type.html.twig
+++ b/lib/easy-seo-bundle/src/Resources/views/fields/text_counter_type.html.twig
@@ -1,0 +1,38 @@
+{% block text_counter_widget %}
+    {% set hasLimit = form.vars.attr.limit is defined and form.vars.attr.limit > 0 %}
+    {% set limit = 0 %}
+
+    <input type="text" name="{{ form.vars.full_name }}" id="{{ form.vars.id }}" class="form-control"
+           value="{{ form.vars.value }}">
+
+    <small class="form-help">
+        <span id="{{ form.vars.id }}_length">{{ form.vars.value|length }}</span>
+        {% if hasLimit %}
+            {% set limit = form.vars.attr.limit %}
+            / {{ form.vars.attr.limit }}
+        {% endif %}
+        caractères
+    </small>
+
+    <script type="application/javascript">
+        var data{{ form.vars.id }} = {
+            field: document.getElementById('{{ form.vars.id }}'),
+            lengthContainer: document.getElementById('{{ form.vars.id }}_length'),
+            initialLength: {{ form.vars.value|length }},
+            previousValue: '{{ form.vars.value }}'
+        }
+
+        function handleValue{{ form.vars.id }}(event) {
+            if (event.target.value.length >= 0 && (event.target.value.length <= {{ limit }} || {{ limit }} === 0)) {
+                data{{ form.vars.id }}.lengthContainer.innerText = event.target.value.length;
+                data{{ form.vars.id }}.previousValue = event.target.value;
+            } else {
+                data{{ form.vars.id }}.field.value = data{{ form.vars.id }}.previousValue;
+            }
+        }
+
+        data{{ form.vars.id }}.field.addEventListener('input', function (event) {
+            handleValue{{ form.vars.id }}(event);
+        });
+    </script>
+{% endblock %}

--- a/lib/easy-seo-bundle/src/Resources/views/fields/textarea_counter_type.html.twig
+++ b/lib/easy-seo-bundle/src/Resources/views/fields/textarea_counter_type.html.twig
@@ -1,0 +1,39 @@
+{% block textarea_counter_widget %}
+    {% set hasLimit = form.vars.attr.limit is defined and form.vars.attr.limit > 0 %}
+    {% set limit = 0 %}
+
+    <textarea name="{{ form.vars.full_name }}" id="{{ form.vars.id }}" class="form-control">
+        {{- form.vars.value -}}
+    </textarea>
+
+    <small class="form-help">
+        <span id="{{ form.vars.id }}_length">{{ form.vars.value|length }}</span>
+        {% if hasLimit %}
+            {% set limit = form.vars.attr.limit %}
+            / {{ form.vars.attr.limit }}
+        {% endif %}
+        caractères
+    </small>
+
+    <script type="application/javascript">
+        var data{{ form.vars.id }} = {
+            field: document.getElementById('{{ form.vars.id }}'),
+            lengthContainer: document.getElementById('{{ form.vars.id }}_length'),
+            initialLength: {{ form.vars.value|length }},
+            previousValue: '{{ form.vars.value }}'
+        }
+
+        function handleValue{{ form.vars.id }}(event) {
+            if (event.target.value.length >= 0 && (event.target.value.length <= {{ limit }} || {{ limit }} === 0)) {
+                data{{ form.vars.id }}.lengthContainer.innerText = event.target.value.length;
+                data{{ form.vars.id }}.previousValue = event.target.value;
+            } else {
+                data{{ form.vars.id }}.field.value = data{{ form.vars.id }}.previousValue;
+            }
+        }
+
+        data{{ form.vars.id }}.field.addEventListener('input', function (event) {
+            handleValue{{ form.vars.id }}(event);
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
Added new text and textarea counter field types to the EasySeoBundle library.

These counter fields display the length of the current field's value and, if a limit attribute is present, the imposed character count limit. The front-end validation then prevents the user from exceeding this set character limit.

This feature brings improvement in user interaction experience by providing immediate feedback on the character limit. It also reduces the chances of backend validation failures due to excessive character counts.