### PR TITLE
Add tests for basic page loading

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
+        <server name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data.db" />
     </php>
 
     <testsuites>

--- a/tests/PageLoadTest.php
+++ b/tests/PageLoadTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class PageLoadTest extends WebTestCase
+{
+    public function testHomepageLoads(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(true);
+        $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testChildPageLoads(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(true);
+        $client->request('GET', '/child-page/');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testSubChildPageLoads(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(true);
+        $client->request('GET', '/child-page/sub-child-page/');
+
+        self::assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary
- add WebTestCase to ensure homepage, child page and sub-child page load correctly
- configure PHPUnit to use SQLite

## Testing
- `composer unit-tests`

------
https://chatgpt.com/codex/tasks/task_e_6842bac1f1048323acdbb17a16747b28