### PR TITLE
Add unit tests and fixtures for EasyRedirectBundle

### DIFF
--- a/src/DataFixtures/RedirectFixtures.php
+++ b/src/DataFixtures/RedirectFixtures.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use App\Entity\EasyRedirect\Redirect;
+
+class RedirectFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $redirect = new Redirect('/old-path', '/new-path');
+        $manager->persist($redirect);
+        $manager->flush();
+    }
+}

--- a/tests/EasyRedirectBundle/Admin/EasyRedirectTraitTest.php
+++ b/tests/EasyRedirectBundle/Admin/EasyRedirectTraitTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyRedirectBundle\Admin;
+
+use Adeliom\EasyRedirectBundle\Admin\EasyRedirectTrait;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+final class EasyRedirectTraitTest extends TestCase
+{
+    public function testConfigRedirectEntryReturnsMenuItems(): void
+    {
+        $bag = new ParameterBag([
+            'easy_redirect.redirect_class' => 'Redirect',
+            'easy_redirect.not_found_class' => 'NotFound',
+        ]);
+        $container = new Container($bag);
+        $container->set('parameter_bag', $bag);
+
+        $object = new class($container) {
+            use EasyRedirectTrait;
+            public function __construct(public Container $container) {}
+        };
+
+        $items = iterator_to_array($object->configRedirectEntry());
+        self::assertCount(3, $items);
+        foreach ($items as $item) {
+            self::assertInstanceOf(MenuItemInterface::class, $item);
+        }
+    }
+}

--- a/tests/EasyRedirectBundle/Admin/NotFoundCrudCrontrollerTest.php
+++ b/tests/EasyRedirectBundle/Admin/NotFoundCrudCrontrollerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyRedirectBundle\Admin;
+
+use Adeliom\EasyRedirectBundle\Admin\NotFoundCrudCrontroller;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+final class NotFoundCrudCrontrollerTest extends TestCase
+{
+    private function createController(): NotFoundCrudCrontroller
+    {
+        $bag = $this->createMock(ParameterBagInterface::class);
+        $urlGenerator = (new \ReflectionClass(AdminUrlGenerator::class))->newInstanceWithoutConstructor();
+
+        return new class($bag, $urlGenerator) extends NotFoundCrudCrontroller {
+            public static function getEntityFqcn(): string
+            {
+                return 'NotFound';
+            }
+        };
+    }
+
+    public function testConfigureFieldsReturnsFields(): void
+    {
+        $controller = $this->createController();
+        $fields = array_map(static fn(FieldInterface $f) => $f, iterator_to_array($controller->configureFields(Crud::PAGE_INDEX)));
+        self::assertCount(5, $fields);
+        self::assertInstanceOf(TextField::class, $fields[0]);
+    }
+}

--- a/tests/EasyRedirectBundle/Admin/RedirectCrudCrontrollerTest.php
+++ b/tests/EasyRedirectBundle/Admin/RedirectCrudCrontrollerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyRedirectBundle\Admin;
+
+use Adeliom\EasyRedirectBundle\Admin\RedirectCrudCrontroller;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use PHPUnit\Framework\TestCase;
+
+final class RedirectCrudCrontrollerTest extends TestCase
+{
+    private function createController(): RedirectCrudCrontroller
+    {
+        $provider = (new \ReflectionClass(AdminContextProvider::class))->newInstanceWithoutConstructor();
+
+        return new class($provider) extends RedirectCrudCrontroller {
+            public static function getEntityFqcn(): string
+            {
+                return 'Redirect';
+            }
+        };
+    }
+
+    public function testConfigureFields(): void
+    {
+        $controller = $this->createController();
+        $fields = array_map(static fn(FieldInterface $f) => $f, iterator_to_array($controller->configureFields(Crud::PAGE_INDEX)));
+        self::assertInstanceOf(TextField::class, $fields[0]);
+    }
+}

--- a/tests/EasyRedirectBundle/Repository/RepositoryInterfaceTest.php
+++ b/tests/EasyRedirectBundle/Repository/RepositoryInterfaceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyRedirectBundle\Repository;
+
+use Adeliom\EasyRedirectBundle\Repository\NotFoundRepositoryInterface;
+use Adeliom\EasyRedirectBundle\Repository\RedirectRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class RepositoryInterfaceTest extends TestCase
+{
+    public function testInterfacesExist(): void
+    {
+        self::assertTrue(interface_exists(NotFoundRepositoryInterface::class));
+        self::assertTrue(interface_exists(RedirectRepositoryInterface::class));
+    }
+}

--- a/tests/EasyRedirectBundle/Service/NotFoundManagerTest.php
+++ b/tests/EasyRedirectBundle/Service/NotFoundManagerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyRedirectBundle\Service;
+
+use Adeliom\EasyRedirectBundle\Entity\NotFound;
+use Adeliom\EasyRedirectBundle\Entity\Redirect;
+use Adeliom\EasyRedirectBundle\Repository\NotFoundRepositoryInterface;
+use Adeliom\EasyRedirectBundle\Service\NotFoundManager;
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class NotFoundManagerTest extends TestCase
+{
+    public function testCreateFromRequestPersistsNewNotFound(): void
+    {
+        $repository = $this->createMock(NotFoundRepositoryInterface::class);
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->with(['path' => '/unknown'])
+            ->willReturn(null);
+
+        $em = $this->createMock(EntityManager::class);
+        $em->expects(self::once())
+            ->method('getRepository')
+            ->with(NotFound::class)
+            ->willReturn($repository);
+        $em->expects(self::once())->method('persist');
+        $em->expects(self::once())->method('flush');
+
+        $manager = new NotFoundManager(NotFound::class, $em);
+        $request = Request::create('/unknown');
+
+        $notFound = $manager->createFromRequest($request);
+
+        self::assertSame('/unknown', $notFound->getPath());
+    }
+
+    public function testRemoveForRedirectDeletesNotFound(): void
+    {
+        $notFound = new NotFound('/a', '/a');
+        $repository = $this->createMock(NotFoundRepositoryInterface::class);
+        $repository->expects(self::once())
+            ->method('findBy')
+            ->with(['path' => '/old', 'host' => 'example.com'])
+            ->willReturn([$notFound]);
+
+        $em = $this->createMock(EntityManager::class);
+        $em->expects(self::once())
+            ->method('getRepository')
+            ->with(NotFound::class)
+            ->willReturn($repository);
+        $em->expects(self::once())->method('remove')->with($notFound);
+        $em->expects(self::once())->method('flush');
+
+        $manager = new NotFoundManager(NotFound::class, $em);
+        $redirect = new Redirect('/old', '/new', 'example.com');
+        $manager->removeForRedirect($redirect);
+    }
+}

--- a/tests/EasyRedirectBundle/Service/RedirectManagerTest.php
+++ b/tests/EasyRedirectBundle/Service/RedirectManagerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyRedirectBundle\Service;
+
+use Adeliom\EasyRedirectBundle\Entity\Redirect;
+use Adeliom\EasyRedirectBundle\Repository\RedirectRepositoryInterface;
+use Adeliom\EasyRedirectBundle\Service\RedirectManager;
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+
+class RedirectManagerTest extends TestCase
+{
+    public function testFindAndUpdateReturnsNullWhenNotFound(): void
+    {
+        $repository = $this->createMock(RedirectRepositoryInterface::class);
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->with(['source' => '/missing', 'host' => ''])
+            ->willReturn(null);
+
+        $em = $this->createMock(EntityManager::class);
+        $em->expects(self::once())
+            ->method('getRepository')
+            ->with(Redirect::class)
+            ->willReturn($repository);
+        $em->expects(self::never())->method('flush');
+
+        $manager = new RedirectManager(Redirect::class, $em);
+
+        self::assertNull($manager->findAndUpdate('/missing'));
+    }
+
+    public function testFindAndUpdateUpdatesRedirect(): void
+    {
+        $redirect = new Redirect('/old', '/new');
+
+        $repository = $this->createMock(RedirectRepositoryInterface::class);
+        $repository->expects(self::once())
+            ->method('findOneBy')
+            ->willReturn($redirect);
+
+        $em = $this->createMock(EntityManager::class);
+        $em->expects(self::once())
+            ->method('getRepository')
+            ->with(Redirect::class)
+            ->willReturn($repository);
+        $em->expects(self::once())->method('flush');
+
+        $manager = new RedirectManager(Redirect::class, $em);
+        $result = $manager->findAndUpdate('/old');
+
+        self::assertSame($redirect, $result);
+        self::assertSame(1, $redirect->getCount());
+        self::assertInstanceOf(\DateTimeInterface::class, $redirect->getLastAccessed());
+    }
+}


### PR DESCRIPTION
## Summary
- add RedirectFixtures for sample redirection data
- add unit tests for EasyRedirectBundle services
- test admin helpers for menu configuration and fields
- ensure repository interfaces exist

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6842d82eb0a883238af5d35ffe105fe1