### PR TITLE
Add tests for common bundle traits

### DIFF
--- a/tests/Fixtures/Traits/IdEntity.php
+++ b/tests/Fixtures/Traits/IdEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntityIdTrait;
+
+class IdEntity
+{
+    use EntityIdTrait;
+}
+

--- a/tests/Fixtures/Traits/NameEntity.php
+++ b/tests/Fixtures/Traits/NameEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntityNameTrait;
+
+class NameEntity
+{
+    use EntityNameTrait;
+}
+

--- a/tests/Fixtures/Traits/NameSlugEntity.php
+++ b/tests/Fixtures/Traits/NameSlugEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntityNameSlugTrait;
+
+class NameSlugEntity
+{
+    use EntityNameSlugTrait;
+}
+

--- a/tests/Fixtures/Traits/PublishableEntity.php
+++ b/tests/Fixtures/Traits/PublishableEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntityPublishableTrait;
+
+class PublishableEntity
+{
+    use EntityPublishableTrait;
+}
+

--- a/tests/Fixtures/Traits/SoftDeletableEntity.php
+++ b/tests/Fixtures/Traits/SoftDeletableEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntitySoftDeletableTrait;
+
+class SoftDeletableEntity
+{
+    use EntitySoftDeletableTrait;
+}
+

--- a/tests/Fixtures/Traits/StatusEntity.php
+++ b/tests/Fixtures/Traits/StatusEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntityStatusTrait;
+
+class StatusEntity
+{
+    use EntityStatusTrait;
+}
+

--- a/tests/Fixtures/Traits/ThreeStateStatusEntity.php
+++ b/tests/Fixtures/Traits/ThreeStateStatusEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntityThreeStateStatusTrait;
+
+class ThreeStateStatusEntity
+{
+    use EntityThreeStateStatusTrait;
+}
+

--- a/tests/Fixtures/Traits/TimestampableEntity.php
+++ b/tests/Fixtures/Traits/TimestampableEntity.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures\Traits;
+
+use Adeliom\EasyCommonBundle\Traits\EntityTimestampableTrait;
+
+class TimestampableEntity
+{
+    use EntityTimestampableTrait;
+}
+

--- a/tests/TraitsTest.php
+++ b/tests/TraitsTest.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use App\Tests\Fixtures\Traits\IdEntity;
+use App\Tests\Fixtures\Traits\NameEntity;
+use App\Tests\Fixtures\Traits\NameSlugEntity;
+use App\Tests\Fixtures\Traits\PublishableEntity;
+use App\Tests\Fixtures\Traits\SoftDeletableEntity;
+use App\Tests\Fixtures\Traits\StatusEntity;
+use App\Tests\Fixtures\Traits\ThreeStateStatusEntity;
+use App\Tests\Fixtures\Traits\TimestampableEntity;
+use Adeliom\EasyCommonBundle\Enum\ThreeStateStatusEnum;
+use PHPUnit\Framework\TestCase;
+use DateTime;
+use DateTimeImmutable;
+use ReflectionClass;
+
+class TraitsTest extends TestCase
+{
+    public function testEntityIdTrait(): void
+    {
+        $entity = new IdEntity();
+        self::assertNull($entity->getId());
+
+        $ref = new ReflectionClass($entity);
+        $prop = $ref->getProperty('id');
+        $prop->setAccessible(true);
+        $prop->setValue($entity, 42);
+        self::assertSame(42, $entity->getId());
+    }
+
+    public function testEntityNameTrait(): void
+    {
+        $entity = new NameEntity();
+        $entity->setName('Foo');
+        self::assertSame('Foo', $entity->getName());
+        self::assertSame('Foo', (string) $entity);
+    }
+
+    public function testEntityNameSlugTrait(): void
+    {
+        $entity = new NameSlugEntity();
+        $entity->setName('Foo');
+        $entity->setSlug('foo');
+        self::assertSame('Foo', $entity->getName());
+        self::assertSame('foo', $entity->getSlug());
+        self::assertSame('Foo', (string) $entity);
+    }
+
+    public function testEntityPublishableTrait(): void
+    {
+        $entity = new PublishableEntity();
+        self::assertTrue($entity->isPublished());
+
+        $entity->setPublishDate(new DateTime('+1 day'));
+        self::assertFalse($entity->isPublished());
+
+        $entity->setPublishDate(new DateTime('-1 day'));
+        $entity->setUnpublishDate(new DateTime('+1 day'));
+        self::assertTrue($entity->isPublished());
+    }
+
+    public function testEntitySoftDeletableTrait(): void
+    {
+        $entity = new SoftDeletableEntity();
+        self::assertFalse($entity->isDeleted());
+
+        $ref = new ReflectionClass($entity);
+        $prop = $ref->getProperty('deletedAt');
+        $prop->setAccessible(true);
+        $prop->setValue($entity, new DateTime());
+        self::assertTrue($entity->isDeleted());
+
+        $entity->recover();
+        self::assertFalse($entity->isDeleted());
+    }
+
+    public function testEntityStatusTrait(): void
+    {
+        $entity = new StatusEntity();
+        self::assertFalse($entity->getStatus());
+        $entity->setStatus(true);
+        self::assertTrue($entity->getStatus());
+    }
+
+    public function testEntityThreeStateStatusTrait(): void
+    {
+        $entity = new ThreeStateStatusEntity();
+        self::assertSame(ThreeStateStatusEnum::UNPUBLISHED, $entity->getState());
+        self::assertTrue($entity->isState(ThreeStateStatusEnum::UNPUBLISHED));
+        $entity->setState(ThreeStateStatusEnum::PUBLISHED);
+        self::assertTrue($entity->isState(ThreeStateStatusEnum::PUBLISHED));
+    }
+
+    public function testEntityTimestampableTrait(): void
+    {
+        $entity = new TimestampableEntity();
+        self::assertInstanceOf(DateTimeImmutable::class, $entity->getCreatedAt());
+        self::assertInstanceOf(DateTime::class, $entity->getUpdatedAt());
+
+        $future = new DateTimeImmutable('+1 day');
+        $entity->setUpdatedAt($future);
+        self::assertSame($future, $entity->getUpdatedAt());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add fixture entities for common bundle traits
- add comprehensive PHPUnit tests for each trait

## Testing
- `composer unit-tests`

------
https://chatgpt.com/codex/tasks/task_e_6843309596b08323a2fefb031dbb8ae3