### PR TITLE
Add unit tests for easy-seo bundle

### DIFF
--- a/tests/EasySeo/Admin/SEOFieldCountTest.php
+++ b/tests/EasySeo/Admin/SEOFieldCountTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Admin;
+
+use Adeliom\EasySeoBundle\Admin\Field\SEOFieldCount;
+use Adeliom\EasySeoBundle\Form\SeoCountType;
+use PHPUnit\Framework\TestCase;
+
+final class SEOFieldCountTest extends TestCase
+{
+    public function testNew(): void
+    {
+        $field = SEOFieldCount::new('seo', 'label');
+        $dto = $field->getAsDto();
+
+        self::assertSame('seo', $dto->getProperty());
+        self::assertSame('label', $dto->getLabel());
+        self::assertSame('@EasySeo/seo-detail.html.twig', $dto->getTemplatePath());
+        self::assertSame(SeoCountType::class, $dto->getFormType());
+        self::assertSame('field-seo', trim($dto->getCssClass()));
+    }
+}

--- a/tests/EasySeo/Admin/SEOFieldTest.php
+++ b/tests/EasySeo/Admin/SEOFieldTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Admin;
+
+use Adeliom\EasySeoBundle\Admin\Field\SEOField;
+use Adeliom\EasySeoBundle\Form\SeoType;
+use PHPUnit\Framework\TestCase;
+
+final class SEOFieldTest extends TestCase
+{
+    public function testNew(): void
+    {
+        $field = SEOField::new('seo', 'label');
+        $dto = $field->getAsDto();
+
+        self::assertSame('seo', $dto->getProperty());
+        self::assertSame('label', $dto->getLabel());
+        self::assertSame('@EasySeo/seo-detail.html.twig', $dto->getTemplatePath());
+        self::assertSame(SeoType::class, $dto->getFormType());
+        self::assertSame('field-seo', trim($dto->getCssClass()));
+
+        $assets = $dto->getAssets()->getCssAssets();
+        $paths = array_map(static fn($asset) => $asset->getValue(), $assets);
+        self::assertContains('bundles/easyseo/seo-form.css', $paths);
+    }
+}

--- a/tests/EasySeo/DataCollector/SeoCollectorTest.php
+++ b/tests/EasySeo/DataCollector/SeoCollectorTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\DataCollector;
+
+use Adeliom\EasySeoBundle\DataCollector\SeoCollector;
+use Adeliom\EasySeoBundle\Services\BreadcrumbCollection;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use PHPUnit\Framework\TestCase;
+
+final class SeoCollectorTest extends TestCase
+{
+    public function testCollectParsesHtml(): void
+    {
+        $breadcrumb = new BreadcrumbCollection();
+        $collector = new SeoCollector($breadcrumb, [], true, []);
+
+        $html = '<html><head><title>My Title</title>' .
+            '<meta name="description" content="Short desc" />' .
+            '<meta name="keywords" content="k1" />' .
+            '<meta name="robots" content="index" />' .
+            '<meta name="page-key" content="key" />' .
+            '<link rel="canonical" href="https://example.com" />' .
+            '<meta property="og:image" content="image.jpg" />' .
+            '</head><body></body></html>';
+
+        $request = new Request([], [], ['_route' => 'home']);
+        $response = new Response($html);
+
+        $collector->collect($request, $response);
+
+        self::assertSame('My Title', (string) $collector->getTitle()['value']);
+        self::assertSame('Short desc', (string) $collector->getDescription()['value']);
+        self::assertTrue(isset($collector->keywords));
+        self::assertTrue(isset($collector->robots));
+        self::assertTrue(isset($collector->pageKey));
+        self::assertTrue(isset($collector->canonical));
+        self::assertTrue(isset($collector->cover));
+    }
+}

--- a/tests/EasySeo/Form/Fields/TextCounterTypeTest.php
+++ b/tests/EasySeo/Form/Fields/TextCounterTypeTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Form\Fields;
+
+use Adeliom\EasySeoBundle\Form\Fields\TextCounterType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class TextCounterTypeTest extends TestCase
+{
+    public function testProperties(): void
+    {
+        $type = new TextCounterType();
+
+        self::assertSame('text_counter', $type->getBlockPrefix());
+        self::assertSame(TextType::class, $type->getParent());
+        self::assertSame('text_counter', $type->getWidgetPrefix());
+    }
+}

--- a/tests/EasySeo/Form/Fields/TextareaCounterTypeTest.php
+++ b/tests/EasySeo/Form/Fields/TextareaCounterTypeTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Form\Fields;
+
+use Adeliom\EasySeoBundle\Form\Fields\TextareaCounterType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+final class TextareaCounterTypeTest extends TestCase
+{
+    public function testProperties(): void
+    {
+        $type = new TextareaCounterType();
+
+        self::assertSame('textarea_counter', $type->getBlockPrefix());
+        self::assertSame(TextareaType::class, $type->getParent());
+        self::assertSame('textarea_counter', $type->getWidgetPrefix());
+    }
+}

--- a/tests/EasySeo/Form/SeoCountTypeTest.php
+++ b/tests/EasySeo/Form/SeoCountTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Form;
+
+use Adeliom\EasySeoBundle\Entity\SEO;
+use Adeliom\EasySeoBundle\Form\SeoCountType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class SeoCountTypeTest extends TestCase
+{
+    public function testConfigureOptions(): void
+    {
+        $type = new SeoCountType();
+        $resolver = new OptionsResolver();
+        $type->configureOptions($resolver);
+        $options = $resolver->resolve();
+
+        self::assertSame(SEO::class, $options['data_class']);
+        self::assertFalse($options['label']);
+        self::assertSame('easy_seo', $type->getBlockPrefix());
+    }
+}

--- a/tests/EasySeo/Form/SeoTypeTest.php
+++ b/tests/EasySeo/Form/SeoTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Form;
+
+use Adeliom\EasySeoBundle\Entity\SEO;
+use Adeliom\EasySeoBundle\Form\SeoType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class SeoTypeTest extends TestCase
+{
+    public function testConfigureOptions(): void
+    {
+        $type = new SeoType();
+        $resolver = new OptionsResolver();
+        $type->configureOptions($resolver);
+        $options = $resolver->resolve();
+
+        self::assertSame(SEO::class, $options['data_class']);
+        self::assertFalse($options['label']);
+        self::assertSame('easy_seo', $type->getBlockPrefix());
+    }
+}

--- a/tests/EasySeo/Services/BreadcrumbCollectionTest.php
+++ b/tests/EasySeo/Services/BreadcrumbCollectionTest.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Services;
+
+use Adeliom\EasySeoBundle\Services\BreadcrumbCollection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class BreadcrumbCollectionTest extends TestCase
+{
+    public function testAddSimpleItem(): void
+    {
+        $collection = new BreadcrumbCollection();
+        $collection->addSimpleItem('Home', '/');
+
+        self::assertSame([
+            ['linkName' => 'Home', 'target' => '/', 'object' => null],
+        ], $collection->getItems());
+    }
+
+    public function testAddRouteItem(): void
+    {
+        $generator = new class() implements UrlGeneratorInterface {
+            public function generate(
+                string $name,
+                array $parameters = [],
+                int $referenceType = self::ABSOLUTE_PATH
+            ): string {
+                return '/' . $name;
+            }
+
+            public function setContext(\Symfony\Component\Routing\RequestContext $context): void {}
+            public function getContext(): \Symfony\Component\Routing\RequestContext { return new \Symfony\Component\Routing\RequestContext(); }
+        };
+
+        $collection = new BreadcrumbCollection();
+        $collection->setGenerator($generator);
+        $collection->addRouteItem('Home', ['route' => 'homepage']);
+
+        self::assertSame([
+            ['linkName' => 'Home', 'target' => '/homepage', 'object' => null],
+        ], $collection->getItems());
+    }
+}

--- a/tests/EasySeo/Traits/EntitySeoTraitTest.php
+++ b/tests/EasySeo/Traits/EntitySeoTraitTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Traits;
+
+use Adeliom\EasySeoBundle\Entity\SEO;
+use Adeliom\EasySeoBundle\Traits\EntitySeoTrait;
+use PHPUnit\Framework\TestCase;
+
+final class EntitySeoTraitTest extends TestCase
+{
+    private function getEntity(): object
+    {
+        return new class() {
+            use EntitySeoTrait;
+        };
+    }
+
+    public function testDefaultSeo(): void
+    {
+        $entity = $this->getEntity();
+        self::assertInstanceOf(SEO::class, $entity->getSEO());
+    }
+
+    public function testSetSeo(): void
+    {
+        $entity = $this->getEntity();
+        $seo = new SEO();
+        $seo->title = 'Test';
+        $entity->setSEO($seo);
+
+        self::assertSame('Test', $entity->getSEO()->title);
+    }
+}

--- a/tests/EasySeo/Twig/EasySeoExtensionTest.php
+++ b/tests/EasySeo/Twig/EasySeoExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasySeo\Twig;
+
+use Adeliom\EasySeoBundle\Entity\SEO;
+use Adeliom\EasySeoBundle\Services\BreadcrumbCollection;
+use Adeliom\EasySeoBundle\Twig\EasySeoExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class EasySeoExtensionTest extends TestCase
+{
+    public function testRenderFunctions(): void
+    {
+        $loader = new ArrayLoader([
+            '@EasySeo/block-breadcrumb.html.twig' => 'bc={{ data|length }}',
+            '@EasySeo/block-metas.html.twig' => 'title={{ data.title }}',
+        ]);
+        $twig = new Environment($loader);
+        $dispatcher = new EventDispatcher();
+        $breadcrumb = new BreadcrumbCollection();
+        $breadcrumb->addSimpleItem('Home', '/');
+
+        $extension = new EasySeoExtension(
+            $twig,
+            $dispatcher,
+            $breadcrumb,
+            ['separator' => '|', 'suffix' => 'Site'],
+            []
+        );
+
+        $seo = new SEO();
+        $seo->title = 'Welcome';
+        $title = $extension->renderSeoTitle($seo);
+        self::assertSame('Welcome | Site', $title);
+
+        $markup = $extension->renderSeoMetas($seo);
+        self::assertSame('title=Welcome', (string) $markup);
+
+        $breadcrumbMarkup = $extension->renderBreadcrumb();
+        self::assertSame('bc=1', (string) $breadcrumbMarkup);
+    }
+}

--- a/tests/Fixtures/SeoFactory.php
+++ b/tests/Fixtures/SeoFactory.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures;
+
+use Adeliom\EasySeoBundle\Entity\SEO;
+
+final class SeoFactory
+{
+    public static function createSeo(
+        string $title = 'Title',
+        string $description = 'Description',
+        string $keywords = 'keyword',
+        string $cannonical = '/url',
+        ?string $key = 'key'
+    ): SEO {
+        $seo = new SEO();
+        $seo->title = $title;
+        $seo->description = $description;
+        $seo->keywords = $keywords;
+        $seo->cannonical = $cannonical;
+        $seo->key = $key;
+        return $seo;
+    }
+}

--- a/tests/config/easy_seo.yaml
+++ b/tests/config/easy_seo.yaml
@@ -1,0 +1,8 @@
+easy_seo:
+  title:
+    suffix: TEST
+    separator: |
+  breadcrumbs:
+    class: breadcrumb
+  enable_profiler: false
+  ignore_profiler: []


### PR DESCRIPTION
## Summary
- add fixtures for testing SEO entities
- add PHPUnit tests for EasySeo bundle classes
- cover Admin fields, DataCollector, Form types, services, traits and Twig extension
- provide test configuration for easy_seo

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_684334661dcc83238905d1a50e76c31b