### PR TITLE
Add tests for EasyConfigBundle

### DIFF
--- a/tests/EasyConfigBundle/Controller/EasyConfigCrudControllerTest.php
+++ b/tests/EasyConfigBundle/Controller/EasyConfigCrudControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyConfigBundle\Controller;
+
+use Adeliom\EasyConfigBundle\Controller\Admin\EasyConfigCrudController;
+use Adeliom\EasyConfigBundle\Entity\Config;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use PHPUnit\Framework\TestCase;
+
+class EasyConfigCrudControllerTest extends TestCase
+{
+    private function getController(): TestController
+    {
+        return new TestController();
+    }
+
+    public function testAvailableTypes(): void
+    {
+        $controller = $this->getController();
+        $types = $controller->publicGetAvailableTypes();
+
+        self::assertArrayHasKey('easy_config.types.text', $types);
+        self::assertContains('text', $types);
+    }
+
+    public function testFieldMap(): void
+    {
+        $controller = $this->getController();
+        $map = $controller->publicGetFieldMap();
+
+        self::assertArrayHasKey('text', $map);
+        self::assertSame(['text'], $map['text']);
+    }
+
+    public function testIsEditable(): void
+    {
+        $config = (new Config())->setType('text');
+        $controller = $this->getController();
+
+        self::assertTrue($controller->publicIsEditable('text', $config, Crud::PAGE_NEW));
+
+        $ref = new \ReflectionProperty(Config::class, 'id');
+        $ref->setAccessible(true);
+        $ref->setValue($config, 1);
+
+        self::assertFalse($controller->publicIsEditable('json', $config, Crud::PAGE_DETAIL));
+        self::assertTrue($controller->publicIsEditable('text', $config, Crud::PAGE_DETAIL));
+        self::assertTrue($controller->publicIsEditable('text', $config, Crud::PAGE_EDIT));
+    }
+}
+
+class TestController extends EasyConfigCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Config::class;
+    }
+
+    public function publicGetAvailableTypes(): array
+    {
+        return $this->getAvailableTypes();
+    }
+
+    public function publicGetFieldMap(): array
+    {
+        return $this->getFieldMap();
+    }
+
+    public function publicIsEditable(string $type, object $config, string $pageName): bool
+    {
+        return self::isEditable($type, $config, $pageName);
+    }
+}

--- a/tests/EasyConfigBundle/Controller/EasyConfigTraitTest.php
+++ b/tests/EasyConfigBundle/Controller/EasyConfigTraitTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyConfigBundle\Controller;
+
+use Adeliom\EasyConfigBundle\Controller\Admin\EasyConfigTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class EasyConfigTraitTest extends TestCase
+{
+    public function testConfigMenuEntryReturnsCrudItem(): void
+    {
+        $container = new Container();
+        $container->set('parameter_bag', new ParameterBag(['easy_config.config_class' => 'App\\Entity\\EasyConfig\\Config']));
+
+        $object = new class($container) {
+            use EasyConfigTrait;
+            public function __construct(public Container $container)
+            {
+            }
+        };
+
+        $items = iterator_to_array($object->configMenuEntry());
+        self::assertCount(1, $items);
+        $item = $items[0];
+        $params = $item->getAsDto()->getRouteParameters();
+        self::assertSame('App\\Entity\\EasyConfig\\Config', $params['entityFqcn']);
+    }
+}

--- a/tests/EasyConfigBundle/DatabaseSetupTrait.php
+++ b/tests/EasyConfigBundle/DatabaseSetupTrait.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyConfigBundle;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+
+trait DatabaseSetupTrait
+{
+    private string $originalDsn = '';
+
+    protected function bootKernelWithMemoryDatabase(): EntityManagerInterface
+    {
+        $this->originalDsn = $_ENV['DATABASE_URL'] ?? (string) getenv('DATABASE_URL');
+        putenv('DATABASE_URL=sqlite:///:memory:');
+        $_ENV['DATABASE_URL'] = 'sqlite:///:memory:';
+        $_SERVER['DATABASE_URL'] = 'sqlite:///:memory:';
+
+        self::bootKernel();
+        $em = static::getContainer()->get('doctrine')->getManager();
+        $this->initSchema($em);
+
+        return $em;
+    }
+
+    protected function restoreDatabaseEnv(): void
+    {
+        if ($this->originalDsn !== '') {
+            putenv('DATABASE_URL='.$this->originalDsn);
+            $_ENV['DATABASE_URL'] = $this->originalDsn;
+            $_SERVER['DATABASE_URL'] = $this->originalDsn;
+        }
+    }
+
+    private function initSchema(EntityManagerInterface $em): void
+    {
+        $tool = new SchemaTool($em);
+        $metadata = $em->getMetadataFactory()->getAllMetadata();
+        $tool->dropSchema($metadata);
+        $tool->createSchema($metadata);
+    }
+}

--- a/tests/EasyConfigBundle/Fixtures/ConfigFixture.php
+++ b/tests/EasyConfigBundle/Fixtures/ConfigFixture.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyConfigBundle\Fixtures;
+
+use App\Entity\EasyConfig\Config;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class ConfigFixture extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $text = (new Config())
+            ->setKey('site_name')
+            ->setName('Site name')
+            ->setType('text')
+            ->setValue('EasyAdmin');
+        $manager->persist($text);
+
+        $json = (new Config())
+            ->setKey('settings')
+            ->setName('Settings')
+            ->setType('json')
+            ->setValue(json_encode(['foo' => 'bar'], JSON_THROW_ON_ERROR));
+        $manager->persist($json);
+
+        $manager->flush();
+    }
+}

--- a/tests/EasyConfigBundle/Repository/ConfigRepositoryTest.php
+++ b/tests/EasyConfigBundle/Repository/ConfigRepositoryTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyConfigBundle\Repository;
+
+use App\Tests\EasyConfigBundle\DatabaseSetupTrait;
+use App\Tests\EasyConfigBundle\Fixtures\ConfigFixture;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ConfigRepositoryTest extends KernelTestCase
+{
+    use DatabaseSetupTrait;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->bootKernelWithMemoryDatabase();
+        (new ConfigFixture())->load($this->em);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->restoreDatabaseEnv();
+    }
+
+    public function testGetByKey(): void
+    {
+        $repository = static::getContainer()->get('easy_config.config_repository');
+        $config = $repository->getByKey('site_name');
+
+        self::assertNotNull($config);
+        self::assertSame('EasyAdmin', $config->getValue());
+    }
+}

--- a/tests/EasyConfigBundle/Twig/EasyConfigExtensionTest.php
+++ b/tests/EasyConfigBundle/Twig/EasyConfigExtensionTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyConfigBundle\Twig;
+
+use Adeliom\EasyConfigBundle\Twig\EasyConfigExtension;
+use App\Tests\EasyConfigBundle\DatabaseSetupTrait;
+use App\Tests\EasyConfigBundle\Fixtures\ConfigFixture;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Twig\Environment;
+
+class EasyConfigExtensionTest extends KernelTestCase
+{
+    use DatabaseSetupTrait;
+
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->bootKernelWithMemoryDatabase();
+        (new ConfigFixture())->load($this->em);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->restoreDatabaseEnv();
+    }
+
+    public function testGetConfigReturnsTextValue(): void
+    {
+        $twig = static::getContainer()->get(Environment::class);
+        /** @var EasyConfigExtension $extension */
+        $extension = static::getContainer()->get(EasyConfigExtension::class);
+        $result = $extension->getConfig($twig, [], 'site_name');
+
+        self::assertSame('EasyAdmin', (string) $result);
+    }
+
+    public function testGetConfigDecodesJson(): void
+    {
+        $twig = static::getContainer()->get(Environment::class);
+        $extension = static::getContainer()->get(EasyConfigExtension::class);
+        $result = $extension->getConfig($twig, [], 'settings');
+
+        self::assertSame(['foo' => 'bar'], $result);
+    }
+
+    public function testGetConfigReturnsArrayWhenNotDirect(): void
+    {
+        $twig = static::getContainer()->get(Environment::class);
+        $extension = static::getContainer()->get(EasyConfigExtension::class);
+        $result = $extension->getConfig($twig, [], 'site_name', false);
+
+        self::assertSame('text', $result['type']);
+        self::assertSame('EasyAdmin', $result['value']);
+        self::assertSame('EasyAdmin', $result['raw_value']);
+    }
+}


### PR DESCRIPTION
## Summary
- add fixtures for config entity
- cover EasyConfigCrudController utilities
- test ConfigRepository for key lookup
- cover Twig extension logic with config values
- use memory database in tests to avoid side effects

## Testing
- `vendor/bin/phpunit tests/EasyConfigBundle --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6843336046908323a58a5b0379c45668