### PR TITLE
Add tests for EasyAdminUserBundle

### DIFF
--- a/tests/UserBundle/AddUserCommandTest.php
+++ b/tests/UserBundle/AddUserCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle;
+
+use Adeliom\EasyAdminUserBundle\Command\AddUserCommand;
+use Adeliom\EasyAdminUserBundle\Entity\User;
+use Adeliom\EasyAdminUserBundle\Repository\UserRepository;
+use Adeliom\EasyAdminUserBundle\Utils\Validator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+class AddUserCommandTest extends TestCase
+{
+    public function testExecuteCreatesUser(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects(self::once())->method('persist');
+        $em->expects(self::once())->method('flush');
+
+        $hasher = $this->createMock(UserPasswordHasherInterface::class);
+        $hasher->method('hashPassword')->willReturn('hashed');
+
+        $repo = $this->createMock(UserRepository::class);
+        $repo->method('findOneBy')->willReturn(null);
+        $repo->method('getClassName')->willReturn(User::class);
+
+        $command = new AddUserCommand($em, $hasher, new Validator(), $repo);
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'email' => 'foo@example.com',
+            'password' => 'secret1',
+            '--admin' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('successfully created', $tester->getDisplay());
+    }
+}

--- a/tests/UserBundle/ControllerTest.php
+++ b/tests/UserBundle/ControllerTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ControllerTest extends WebTestCase
+{
+    public function testLoginPage(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/admin/login');
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testCheckEmailPage(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/admin/reset-password/check-email');
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/UserBundle/DoctrineMappingListenerTest.php
+++ b/tests/UserBundle/DoctrineMappingListenerTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle;
+
+use Adeliom\EasyAdminUserBundle\Entity\ResetPasswordRequest;
+use Adeliom\EasyAdminUserBundle\Entity\User;
+use Adeliom\EasyAdminUserBundle\EventListener\DoctrineMappingListener;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class DoctrineMappingListenerTest extends TestCase
+{
+    public function testMappingIsAdded(): void
+    {
+        $listener = new DoctrineMappingListener(User::class, ResetPasswordRequest::class);
+        $metadata = new ClassMetadata(ResetPasswordRequest::class);
+        $args = new LoadClassMetadataEventArgs($metadata, $this->createMock(EntityManagerInterface::class));
+
+        $listener->loadClassMetadata($args);
+
+        self::assertTrue($metadata->hasAssociation('user'));
+    }
+}

--- a/tests/UserBundle/Fixture/UserFixture.php
+++ b/tests/UserBundle/Fixture/UserFixture.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle\Fixture;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use App\Entity\EasyAdmin\User;
+
+class UserFixture extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $user = new User();
+        $user->setEmail('user@example.com');
+        $user->setPassword('password');
+        $user->setRoles(['ROLE_USER']);
+
+        $manager->persist($user);
+        $manager->flush();
+    }
+}

--- a/tests/UserBundle/FormTypeTest.php
+++ b/tests/UserBundle/FormTypeTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle;
+
+use Adeliom\EasyAdminUserBundle\Form\ChangePasswordFormType;
+use Adeliom\EasyAdminUserBundle\Form\ResetPasswordRequestFormType;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class FormTypeTest extends KernelTestCase
+{
+    private FormFactoryInterface $factory;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->factory = self::getContainer()->get(FormFactoryInterface::class);
+    }
+
+    public function testChangePasswordFormHasPlainPassword(): void
+    {
+        $form = $this->factory->create(ChangePasswordFormType::class);
+        self::assertTrue($form->has('plainPassword'));
+    }
+
+    public function testResetPasswordRequestFormHasEmail(): void
+    {
+        $form = $this->factory->create(ResetPasswordRequestFormType::class);
+        self::assertTrue($form->has('email'));
+    }
+}

--- a/tests/UserBundle/RepositoryTest.php
+++ b/tests/UserBundle/RepositoryTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle;
+
+use Adeliom\EasyAdminUserBundle\Entity\ResetPasswordRequest;
+use Adeliom\EasyAdminUserBundle\Entity\User;
+use Adeliom\EasyAdminUserBundle\Repository\ResetPasswordRequestRepository;
+use Adeliom\EasyAdminUserBundle\Repository\UserRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityRepository;
+use PHPUnit\Framework\TestCase;
+
+class RepositoryTest extends TestCase
+{
+    public function testCreateResetPasswordRequest(): void
+    {
+        $repo = $this->getMockBuilder(ResetPasswordRequestRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getClassName'])
+            ->getMock();
+        $repo->method('getClassName')->willReturn(ResetPasswordRequest::class);
+        $user = new User();
+        $expires = new DateTimeImmutable('+1 hour');
+
+        $request = $repo->createResetPasswordRequest($user, $expires, 'sel', 'tok');
+
+        self::assertInstanceOf(ResetPasswordRequest::class, $request);
+        self::assertSame($user, $request->getUser());
+    }
+
+    public function testUpgradePassword(): void
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $repo = new UserRepository($registry, User::class);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $ref = new \ReflectionProperty(EntityRepository::class, '_em');
+        $ref->setAccessible(true);
+        $ref->setValue($repo, $em);
+
+        $user = new User();
+        $em->expects(self::once())->method('persist')->with($user);
+        $em->expects(self::once())->method('flush');
+
+        $repo->upgradePassword($user, 'new');
+        self::assertSame('new', $user->getPassword());
+    }
+}

--- a/tests/UserBundle/SecurityTest.php
+++ b/tests/UserBundle/SecurityTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle;
+
+use Adeliom\EasyAdminUserBundle\Security\EasyAdminAuthenticator;
+use Adeliom\EasyAdminUserBundle\Security\EasyAdminUserProvider;
+use Adeliom\EasyAdminUserBundle\Entity\User;
+use Adeliom\EasyAdminUserBundle\Repository\UserRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+
+class SecurityTest extends TestCase
+{
+    public function testAuthenticatorCreatesPassport(): void
+    {
+        $urlGen = $this->createMock(UrlGeneratorInterface::class);
+        $authenticator = new EasyAdminAuthenticator($urlGen);
+
+        $request = new Request([], [
+            'email' => 'foo@example.com',
+            'password' => 'secret',
+            '_csrf_token' => 'token',
+        ]);
+        $request->setSession(new \Symfony\Component\HttpFoundation\Session\Session(new \Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage()));
+        $passport = $authenticator->authenticate($request);
+
+        /** @var UserBadge $badge */
+        $badge = $passport->getBadge(UserBadge::class);
+        self::assertSame('foo@example.com', $badge->getUserIdentifier());
+    }
+
+    public function testUserProviderLoadsUser(): void
+    {
+        $user = new User();
+        $user->setEmail('foo@example.com');
+
+        $repo = $this->createMock(UserRepository::class);
+        $repo->expects(self::once())->method('findOneBy')->with(['email' => 'foo@example.com'])->willReturn($user);
+
+        $provider = new EasyAdminUserProvider($repo);
+
+        $loaded = $provider->loadUserByIdentifier('foo@example.com');
+        self::assertSame($user, $loaded);
+    }
+}

--- a/tests/UserBundle/ValidatorTest.php
+++ b/tests/UserBundle/ValidatorTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\UserBundle;
+
+use Adeliom\EasyAdminUserBundle\Utils\Validator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+
+class ValidatorTest extends TestCase
+{
+    private Validator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new Validator();
+    }
+
+    public function testValidateEmail(): void
+    {
+        self::assertSame('test@example.com', $this->validator->validateEmail('test@example.com'));
+    }
+
+    public function testValidateEmailThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validateEmail('invalid');
+    }
+
+    public function testValidatePassword(): void
+    {
+        self::assertSame('secret1', $this->validator->validatePassword('secret1'));
+    }
+
+    public function testValidatePasswordThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->validator->validatePassword('bad');
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit tests for EasyAdminUser bundle classes
- create a fixture for sample users

## Testing
- `composer run unit-tests`

------
https://chatgpt.com/codex/tasks/task_e_6843341e0f0c8323b7e07088de061a3b