### PR TITLE
Add PHPUnit tests for EasyBlogBundle

### DIFF
--- a/tests/BlogBundle/BlogTestCase.php
+++ b/tests/BlogBundle/BlogTestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\BlogBundle;
+
+use App\Tests\Fixtures\BlogFixtures;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Adeliom\EasyMediaBundle\Types\EasyMediaType;
+use Adeliom\EasyBlogBundle\EventListener\DoctrineMappingListener;
+use App\Entity\EasyBlog\Post;
+use App\Entity\EasyBlog\Category;
+
+abstract class BlogTestCase extends KernelTestCase
+{
+    protected EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $config = Setup::createAttributeMetadataConfiguration([
+            __DIR__ . '/../../src/Entity/EasyBlog',
+            __DIR__ . '/../../lib/easy-blog-bundle/src/Entity',
+            __DIR__ . '/../../lib/easy-seo-bundle/src/Entity',
+            __DIR__ . '/../../lib/easy-media-bundle/src/Entity',
+        ], true);
+
+        if (!Type::hasType('easy_media_type')) {
+            Type::addType('easy_media_type', EasyMediaType::class);
+        }
+
+        $this->em = EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+
+        $this->em->getEventManager()->addEventListener(
+            \Doctrine\ORM\Events::loadClassMetadata,
+            new DoctrineMappingListener(Post::class, Category::class)
+        );
+
+        $tool = new SchemaTool($this->em);
+        $tool->createSchema($this->em->getMetadataFactory()->getAllMetadata());
+
+        (new BlogFixtures())->load($this->em);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->em->clear();
+    }
+}

--- a/tests/BlogBundle/Controller/CategoryControllerTest.php
+++ b/tests/BlogBundle/Controller/CategoryControllerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Tests\BlogBundle\Controller;
+
+use Adeliom\EasyBlogBundle\Controller\CategoryController;
+use Adeliom\EasyBlogBundle\Event\EasyBlogCategoryEvent;
+use App\Entity\EasyBlog\Category;
+use App\Tests\BlogBundle\BlogTestCase;
+use App\Tests\BlogBundle\SimpleManagerRegistry;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Adeliom\EasySeoBundle\Services\BreadcrumbCollection;
+
+class CategoryControllerTest extends BlogTestCase
+{
+    private function createController(): CategoryController
+    {
+        $registry = new SimpleManagerRegistry($this->em);
+        $controller = new CategoryController($registry);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(EasyBlogCategoryEvent::NAME, fn(EasyBlogCategoryEvent $e) => $e);
+
+        $twig = new Environment(new ArrayLoader([
+            '@EasyBlog/front/category.html.twig' => 'category',
+            '@EasyBlog/front/root.html.twig' => 'root',
+        ]));
+
+        $generator = new class() implements \Symfony\Component\Routing\Generator\UrlGeneratorInterface {
+            public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string { return '/'; }
+            public function setContext(\Symfony\Component\Routing\RequestContext $context): void {}
+            public function getContext(): \Symfony\Component\Routing\RequestContext { return new \Symfony\Component\Routing\RequestContext(); }
+        };
+        $breadcrumb = new BreadcrumbCollection();
+        $breadcrumb->setGenerator($generator);
+
+        $container = new Container();
+        $container->set('event_dispatcher', $dispatcher);
+        $container->set('twig', $twig);
+        $container->set('easy_seo.breadcrumb', $breadcrumb);
+        $container->set('parameter_bag', new ParameterBag([
+            'easy_blog.post.class' => \App\Entity\EasyBlog\Post::class,
+            'easy_blog.category.class' => \App\Entity\EasyBlog\Category::class,
+        ]));
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    public function testIndex(): void
+    {
+        $repo = (new SimpleManagerRegistry($this->em))->getRepository(Category::class);
+        $category = $repo->findOneBy(['slug' => 'cat']);
+        $request = new Request([], [], ['_easy_blog_category' => $category]);
+
+        $response = $this->createController()->index($request, 'cat');
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testBlogRoot(): void
+    {
+        $request = new Request([], [], ['_easy_blog_root' => true]);
+
+        $response = $this->createController()->blogRoot($request);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/BlogBundle/Controller/PostControllerTest.php
+++ b/tests/BlogBundle/Controller/PostControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Tests\BlogBundle\Controller;
+
+use Adeliom\EasyBlogBundle\Controller\PostController;
+use Adeliom\EasyBlogBundle\Event\EasyBlogCategoryEvent;
+use App\Entity\EasyBlog\Category;
+use App\Entity\EasyBlog\Post;
+use App\Tests\BlogBundle\BlogTestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Adeliom\EasySeoBundle\Services\BreadcrumbCollection;
+
+class PostControllerTest extends BlogTestCase
+{
+    private function createController(): PostController
+    {
+        $controller = new PostController();
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(EasyBlogCategoryEvent::NAME, fn($e) => $e);
+
+        $twig = new Environment(new ArrayLoader([
+            '@EasyBlog/front/post.html.twig' => 'post',
+        ]));
+        $generator = new class() implements \Symfony\Component\Routing\Generator\UrlGeneratorInterface {
+            public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string { return '/'; }
+            public function setContext(\Symfony\Component\Routing\RequestContext $context): void {}
+            public function getContext(): \Symfony\Component\Routing\RequestContext { return new \Symfony\Component\Routing\RequestContext(); }
+        };
+        $breadcrumb = new BreadcrumbCollection();
+        $breadcrumb->setGenerator($generator);
+
+        $container = new Container();
+        $container->set('event_dispatcher', $dispatcher);
+        $container->set('twig', $twig);
+        $container->set('easy_seo.breadcrumb', $breadcrumb);
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    public function testIndex(): void
+    {
+        $registry = new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em);
+        $category = $registry->getRepository(Category::class)->findOneBy(['slug' => 'cat']);
+        $post = $registry->getRepository(Post::class)->findOneBy(['slug' => 'post-1']);
+
+        $request = new Request([], [], [
+            '_easy_blog_category' => $category,
+            '_easy_blog_post' => $post,
+        ]);
+
+        $response = $this->createController()->index($request, 'cat', 'post-1');
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/BlogBundle/EventListener/BlogListenerTest.php
+++ b/tests/BlogBundle/EventListener/BlogListenerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Tests\BlogBundle\EventListener;
+
+use Adeliom\EasyBlogBundle\EventListener\BlogListener;
+use App\Tests\BlogBundle\BlogTestCase;
+use App\Tests\BlogBundle\SimpleManagerRegistry;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+class BlogListenerTest extends BlogTestCase
+{
+    public function testSetRequestLayoutForPost(): void
+    {
+        $registry = new SimpleManagerRegistry($this->em);
+        $listener = new BlogListener(
+            $registry->getRepository(\App\Entity\EasyBlog\Post::class),
+            $registry->getRepository(\App\Entity\EasyBlog\Category::class),
+            ['root_path' => '/blog']
+        );
+
+        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'localhost', 'REQUEST_URI' => '/blog/cat/post-1']);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $listener->setRequestLayout($event);
+
+        $this->assertTrue($request->attributes->has('_easy_blog_category'));
+        $this->assertTrue($request->attributes->has('_easy_blog_post'));
+    }
+
+    public function testSetRequestLayoutForRoot(): void
+    {
+        $registry = new SimpleManagerRegistry($this->em);
+        $listener = new BlogListener(
+            $registry->getRepository(\App\Entity\EasyBlog\Post::class),
+            $registry->getRepository(\App\Entity\EasyBlog\Category::class),
+            ['root_path' => '/blog']
+        );
+
+        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'localhost', 'REQUEST_URI' => '/blog']);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $listener->setRequestLayout($event);
+
+        $this->assertTrue($request->attributes->has('_easy_blog_root'));
+    }
+}

--- a/tests/BlogBundle/EventListener/DoctrineMappingListenerTest.php
+++ b/tests/BlogBundle/EventListener/DoctrineMappingListenerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Tests\BlogBundle\EventListener;
+
+use Adeliom\EasyBlogBundle\EventListener\DoctrineMappingListener;
+use App\Entity\EasyBlog\Category;
+use App\Entity\EasyBlog\Post;
+use App\Tests\BlogBundle\BlogTestCase;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+class DoctrineMappingListenerTest extends BlogTestCase
+{
+    public function testLoadClassMetadata(): void
+    {
+        $listener = new DoctrineMappingListener(Post::class, Category::class);
+
+        $metaPost = new ClassMetadata(Post::class);
+        $argsPost = new LoadClassMetadataEventArgs($metaPost, $this->em);
+        $listener->loadClassMetadata($argsPost);
+        $this->assertTrue($metaPost->hasAssociation('category'));
+
+        $metaCategory = new ClassMetadata(Category::class);
+        $argsCategory = new LoadClassMetadataEventArgs($metaCategory, $this->em);
+        $listener->loadClassMetadata($argsCategory);
+        $this->assertTrue($metaCategory->hasAssociation('posts'));
+    }
+}

--- a/tests/BlogBundle/EventListener/SitemapSubscriberTest.php
+++ b/tests/BlogBundle/EventListener/SitemapSubscriberTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\BlogBundle\EventListener;
+
+use Adeliom\EasyBlogBundle\EventListener\SitemapSubscriber;
+use App\Entity\EasyBlog\Category;
+use App\Entity\EasyBlog\Post;
+use App\Tests\BlogBundle\BlogTestCase;
+use App\Tests\BlogBundle\SimpleManagerRegistry;
+use Presta\SitemapBundle\Event\SitemapPopulateEvent;
+use Presta\SitemapBundle\Service\UrlContainerInterface;
+use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class SitemapSubscriberTest extends BlogTestCase
+{
+    public function testPopulate(): void
+    {
+        $registry = new SimpleManagerRegistry($this->em);
+        $generator = new class() implements UrlGeneratorInterface {
+            public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
+            {
+                return '/' . $name . '/';
+            }
+            public function getContext(): \Symfony\Component\Routing\RequestContext { return new \Symfony\Component\Routing\RequestContext(); }
+            public function setContext(\Symfony\Component\Routing\RequestContext $context): void {}
+        };
+
+        $container = new class() implements UrlContainerInterface {
+            public array $urls = [];
+            public function addUrl(\Presta\SitemapBundle\Sitemap\Url\Url $url, string $section): void
+            {
+                $this->urls[] = $url;
+            }
+        };
+
+        $event = new SitemapPopulateEvent($container, $generator);
+
+        $subscriber = new SitemapSubscriber(
+            $generator,
+            $registry->getRepository(Post::class),
+            $registry->getRepository(Category::class),
+            true
+        );
+
+        $subscriber->populate($event);
+
+        $this->assertCount(3, $container->urls);
+        $this->assertContainsOnlyInstancesOf(UrlConcrete::class, $container->urls);
+    }
+}

--- a/tests/BlogBundle/Repository/CategoryRepositoryTest.php
+++ b/tests/BlogBundle/Repository/CategoryRepositoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Tests\BlogBundle\Repository;
+
+use App\Entity\EasyBlog\Category;
+use App\Repository\EasyBlog\CategoryRepository;
+use App\Tests\BlogBundle\BlogTestCase;
+use App\Tests\BlogBundle\SimpleManagerRegistry;
+
+class CategoryRepositoryTest extends BlogTestCase
+{
+    public function testGetPublished(): void
+    {
+        $repo = new CategoryRepository(new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em));
+        $result = $repo->getPublished();
+        $this->assertCount(1, $result);
+    }
+
+    public function testGetBySlug(): void
+    {
+        $repo = new CategoryRepository(new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em));
+        $cat = $repo->getBySlug('cat');
+        $this->assertInstanceOf(Category::class, $cat);
+    }
+}

--- a/tests/BlogBundle/Repository/PostRepositoryTest.php
+++ b/tests/BlogBundle/Repository/PostRepositoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Tests\BlogBundle\Repository;
+
+use App\Entity\EasyBlog\Category;
+use App\Entity\EasyBlog\Post;
+use App\Repository\EasyBlog\CategoryRepository;
+use App\Repository\EasyBlog\PostRepository;
+use App\Tests\BlogBundle\BlogTestCase;
+use App\Tests\BlogBundle\SimpleManagerRegistry;
+
+class PostRepositoryTest extends BlogTestCase
+{
+    public function testGetPublished(): void
+    {
+        $repo = new PostRepository(new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em));
+        $posts = $repo->getPublished();
+        $this->assertCount(2, $posts);
+    }
+
+    public function testGetByCategory(): void
+    {
+        $registry = new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em);
+        $repo = new PostRepository($registry);
+        $cat = (new CategoryRepository($registry))->findOneBy(['slug' => 'cat']);
+        $posts = $repo->getByCategory($cat);
+        $this->assertCount(2, $posts);
+    }
+
+    public function testGetBySlug(): void
+    {
+        $registry = new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em);
+        $repo = new PostRepository($registry);
+        $cat = (new CategoryRepository($registry))->findOneBy(['slug' => 'cat']);
+        $post = $repo->getBySlug('post-1', $cat);
+        $this->assertInstanceOf(Post::class, $post);
+        $this->assertSame('post-1', $post->getSlug());
+    }
+}

--- a/tests/BlogBundle/Routing/BlogCategoryLoaderTest.php
+++ b/tests/BlogBundle/Routing/BlogCategoryLoaderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Tests\BlogBundle\Routing;
+
+use Adeliom\EasyBlogBundle\Routing\BlogCategoryLoader;
+use App\Tests\BlogBundle\BlogTestCase;
+use Symfony\Component\Routing\RouteCollection;
+
+class BlogCategoryLoaderTest extends BlogTestCase
+{
+    public function testSupports(): void
+    {
+        $repo = new \App\Repository\EasyBlog\CategoryRepository(new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em));
+        $loader = new BlogCategoryLoader('Controller', '', $repo, ['root_path' => '/blog']);
+        $this->assertTrue($loader->supports(null, 'easy_blog_category'));
+        $this->assertFalse($loader->supports(null, 'foo'));
+    }
+
+    public function testLoad(): void
+    {
+        $repo = new \App\Repository\EasyBlog\CategoryRepository(new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em));
+        $loader = new BlogCategoryLoader('Controller', '', $repo, ['root_path' => '/blog']);
+        $collection = $loader->load([], 'easy_blog_category');
+        $this->assertInstanceOf(RouteCollection::class, $collection);
+        $route = $collection->get('easy_blog_category_index');
+        $this->assertSame('/blog/{category}', $route->getPath());
+    }
+}

--- a/tests/BlogBundle/Routing/BlogPostLoaderTest.php
+++ b/tests/BlogBundle/Routing/BlogPostLoaderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests\BlogBundle\Routing;
+
+use Adeliom\EasyBlogBundle\Routing\BlogPostLoader;
+use App\Tests\BlogBundle\BlogTestCase;
+use Symfony\Component\Routing\RouteCollection;
+
+class BlogPostLoaderTest extends BlogTestCase
+{
+    public function testSupports(): void
+    {
+        $repo = new \App\Repository\EasyBlog\PostRepository(new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em));
+        $loader = new BlogPostLoader('Controller', '', $repo, ['root_path' => '/blog']);
+        $this->assertTrue($loader->supports(null, 'easy_blog_post'));
+        $this->assertFalse($loader->supports(null, 'foo'));
+    }
+
+    public function testLoad(): void
+    {
+        $repo = new \App\Repository\EasyBlog\PostRepository(new \App\Tests\BlogBundle\SimpleManagerRegistry($this->em));
+        $loader = new BlogPostLoader('Controller', '', $repo, ['root_path' => '/blog']);
+        $collection = $loader->load([], 'easy_blog_post');
+        $route = $collection->get('easy_blog_post_index');
+        $this->assertSame('/blog/{category}/{post}', $route->getPath());
+    }
+}

--- a/tests/BlogBundle/SimpleManagerRegistry.php
+++ b/tests/BlogBundle/SimpleManagerRegistry.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\BlogBundle;
+
+use Doctrine\Persistence\ConnectionRegistry;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ObjectManager as DoctrineObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
+
+class SimpleManagerRegistry implements ManagerRegistry
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function getDefaultConnectionName(): string
+    {
+        return 'default';
+    }
+
+    public function getConnection(?string $name = null): Connection
+    {
+        return $this->em->getConnection();
+    }
+
+    public function getConnections(): array
+    {
+        return ['default' => $this->em->getConnection()];
+    }
+
+    public function getConnectionNames(): array
+    {
+        return ['default' => 'default'];
+    }
+
+    public function getDefaultManagerName(): string
+    {
+        return 'default';
+    }
+
+    public function getManager(?string $name = null): DoctrineObjectManager
+    {
+        return $this->em;
+    }
+
+    public function getManagers(): array
+    {
+        return ['default' => $this->em];
+    }
+
+    public function resetManager(?string $name = null): DoctrineObjectManager
+    {
+        return $this->em;
+    }
+
+    public function getAliasNamespace(string $alias): string
+    {
+        return '';
+    }
+
+    public function getManagerNames(): array
+    {
+        return ['default' => 'default'];
+    }
+
+    public function getRepository(string $persistentObject, ?string $persistentManagerName = null): ObjectRepository
+    {
+        $metadata = $this->em->getClassMetadata($persistentObject);
+        $repositoryClass = $metadata->customRepositoryClassName ?? \Doctrine\ORM\EntityRepository::class;
+        if (is_subclass_of($repositoryClass, \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository::class)) {
+            return new $repositoryClass($this);
+        }
+        return new $repositoryClass($this->em, $metadata);
+    }
+
+    public function getManagerForClass(string $class): ?DoctrineObjectManager
+    {
+        return $this->em;
+    }
+}

--- a/tests/Fixtures/BlogFixtures.php
+++ b/tests/Fixtures/BlogFixtures.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Tests\Fixtures;
+
+use Adeliom\EasyCommonBundle\Enum\ThreeStateStatusEnum;
+use App\Entity\EasyBlog\Category;
+use App\Entity\EasyBlog\Post;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class BlogFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $category = new Category();
+        $category->setName('Category 1');
+        $category->setSlug('cat');
+        $category->setStatus(true);
+        $manager->persist($category);
+
+        $post1 = new Post();
+        $post1->setName('Post 1');
+        $post1->setSlug('post-1');
+        $post1->setState(ThreeStateStatusEnum::PUBLISHED);
+        $post1->setPublishDate((new \DateTimeImmutable('-1 day')));
+        $post1->setCategory($category);
+        $manager->persist($post1);
+
+        $post2 = new Post();
+        $post2->setName('Post 2');
+        $post2->setSlug('post-2');
+        $post2->setState(ThreeStateStatusEnum::PUBLISHED);
+        $post2->setPublishDate((new \DateTimeImmutable('-1 day')));
+        $post2->setCategory($category);
+        $manager->persist($post2);
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
## Summary
- add BlogFixtures for test entities
- add BlogTestCase to boot an in-memory Doctrine ORM
- implement SimpleManagerRegistry for repository usage
- test controllers, event listeners, repositories and routing loaders of EasyBlog bundle

## Testing
- `composer unit-tests`

------
https://chatgpt.com/codex/tasks/task_e_6844384052988323b5e7898cf68f72df