### PR TITLE
Add PHPUnit tests for EasyFaq bundle

### DIFF
--- a/tests/EasyFaq/ControllerTest.php
+++ b/tests/EasyFaq/ControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyFaq;
+
+use App\Tests\Fixtures\FaqFixtures;
+use App\Tests\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ControllerTest extends WebTestCase
+{
+    use FixturesTrait;
+
+    public function testCategoryPage(): void
+    {
+        $client = static::createClient();
+        $this->loadFixtures([new FaqFixtures()]);
+        $client->request('GET', '/faq/faq-category');
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testEntryPage(): void
+    {
+        $client = static::createClient();
+        $this->loadFixtures([new FaqFixtures()]);
+        $client->request('GET', '/faq/faq-category/faq-entry');
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/EasyFaq/DoctrineMappingListenerTest.php
+++ b/tests/EasyFaq/DoctrineMappingListenerTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyFaq;
+
+use Adeliom\EasyFaqBundle\EventListener\DoctrineMappingListener;
+use App\Entity\EasyFaq\Category;
+use App\Entity\EasyFaq\Entry;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+
+class DoctrineMappingListenerTest extends KernelTestCase
+{
+    public function testAssociationsAreAdded(): void
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        $listener = new DoctrineMappingListener(Entry::class, Category::class);
+        $entryMetadata = $em->getClassMetadata(Entry::class);
+        $categoryMetadata = $em->getClassMetadata(Category::class);
+        $listener->loadClassMetadata(new LoadClassMetadataEventArgs($entryMetadata, $em));
+        $listener->loadClassMetadata(new LoadClassMetadataEventArgs($categoryMetadata, $em));
+        self::assertTrue($entryMetadata->hasAssociation('category'));
+        self::assertTrue($categoryMetadata->hasAssociation('entries'));
+    }
+}

--- a/tests/EasyFaq/EntryListenerTest.php
+++ b/tests/EasyFaq/EntryListenerTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyFaq;
+
+use Adeliom\EasyFaqBundle\EventListener\EntryListener;
+use App\Tests\Fixtures\FaqFixtures;
+use App\Tests\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class EntryListenerTest extends WebTestCase
+{
+    use FixturesTrait;
+
+    private EntryListener $listener;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loadFixtures([new FaqFixtures()]);
+        $this->listener = new EntryListener(
+            self::getContainer()->get('easy_faq.entry.repository'),
+            self::getContainer()->get('easy_faq.category.repository'),
+            ['root_path' => '/faq']
+        );
+    }
+
+    public function testSetRequestLayout(): void
+    {
+        $request = Request::create('/faq/faq-category/faq-entry');
+        $event = new RequestEvent(self::$kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->listener->setRequestLayout($event);
+
+        self::assertTrue($request->attributes->has('_easy_faq_category'));
+        self::assertTrue($request->attributes->has('_easy_faq_entry'));
+    }
+
+    public function testSetRequestLayoutRoot(): void
+    {
+        $request = Request::create('/faq');
+        $event = new RequestEvent(self::$kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $this->listener->setRequestLayout($event);
+
+        self::assertTrue($request->attributes->getBoolean('_easy_faq_root'));
+    }
+}

--- a/tests/EasyFaq/RepositoryTest.php
+++ b/tests/EasyFaq/RepositoryTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyFaq;
+
+use App\Tests\Fixtures\FaqFixtures;
+use App\Tests\FixturesTrait;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class RepositoryTest extends KernelTestCase
+{
+    use FixturesTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loadFixtures([new FaqFixtures()]);
+    }
+
+    public function testCategoryRepository(): void
+    {
+        $repo = self::getContainer()->get('easy_faq.category.repository');
+        $category = $repo->getBySlug('faq-category');
+        self::assertNotNull($category);
+        self::assertSame('faq-category', $category->getSlug());
+        $all = $repo->getPublished();
+        self::assertGreaterThanOrEqual(1, count($all));
+    }
+
+    public function testEntryRepository(): void
+    {
+        $catRepo = self::getContainer()->get('easy_faq.category.repository');
+        $category = $catRepo->getBySlug('faq-category');
+
+        $repo = self::getContainer()->get('easy_faq.entry.repository');
+        $entry = $repo->getBySlug('faq-entry', $category);
+        self::assertNotNull($entry);
+        self::assertSame('faq-entry', $entry->getSlug());
+        $all = $repo->getByCategory($category);
+        self::assertGreaterThanOrEqual(1, count($all));
+    }
+}

--- a/tests/EasyFaq/RoutingTest.php
+++ b/tests/EasyFaq/RoutingTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyFaq;
+
+use Adeliom\EasyFaqBundle\Routing\FaqCategoryLoader;
+use Adeliom\EasyFaqBundle\Routing\FaqEntryLoader;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouteCollection;
+
+class RoutingTest extends TestCase
+{
+    public function testCategoryLoaderAddsRoute(): void
+    {
+        $loader = new FaqCategoryLoader('Controller', 'Entity', $this->createMock(\Adeliom\EasyFaqBundle\Repository\CategoryRepository::class), ['root_path' => '/faq']);
+        $routes = $loader->load('', 'easy_faq_category');
+        self::assertInstanceOf(RouteCollection::class, $routes);
+        self::assertTrue($routes->get('easy_faq_category_index') !== null);
+        self::assertSame('/faq/{category}', $routes->get('easy_faq_category_index')->getPath());
+    }
+
+    public function testEntryLoaderAddsRoute(): void
+    {
+        $loader = new FaqEntryLoader('Controller', 'Entity', $this->createMock(\Adeliom\EasyFaqBundle\Repository\EntryRepository::class), ['root_path' => '/faq']);
+        $routes = $loader->load('', 'easy_faq_entry');
+        self::assertInstanceOf(RouteCollection::class, $routes);
+        self::assertTrue($routes->get('easy_faq_entry_index') !== null);
+        self::assertSame('/faq/{category}/{entry}', $routes->get('easy_faq_entry_index')->getPath());
+    }
+}

--- a/tests/Fixtures/FaqFixtures.php
+++ b/tests/Fixtures/FaqFixtures.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures;
+
+use Adeliom\EasyCommonBundle\Enum\ThreeStateStatusEnum;
+use App\Entity\EasyFaq\Category;
+use App\Entity\EasyFaq\Entry;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class FaqFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $category = new Category();
+        $category->setName('Faq Category');
+        $category->setSlug('faq-category');
+        $category->setStatus(true);
+
+        $entry = new Entry();
+        $entry->setName('Faq Entry');
+        $entry->setSlug('faq-entry');
+        $entry->setAnswer('Answer');
+        $entry->setCategory($category);
+        $entry->setState(ThreeStateStatusEnum::PUBLISHED);
+        $entry->setPublishDate(new \DateTimeImmutable('-1 day'));
+
+        $manager->persist($category);
+        $manager->persist($entry);
+        $manager->flush();
+    }
+}

--- a/tests/Fixtures/PageFixtures.php
+++ b/tests/Fixtures/PageFixtures.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures;
+
+use Adeliom\EasyCommonBundle\Enum\ThreeStateStatusEnum;
+use App\Entity\EasyPage\Page;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class PageFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $homepage = new Page();
+        $homepage->setName("Page d'accueil");
+        $homepage->setSlug('page-daccueil');
+        $homepage->setState(ThreeStateStatusEnum::PUBLISHED);
+        $homepage->setTemplate('homepage');
+        $manager->persist($homepage);
+
+        $child = new Page();
+        $child->setName('Child page');
+        $child->setSlug('child-page');
+        $child->setState(ThreeStateStatusEnum::PUBLISHED);
+        $child->setParent($homepage);
+        $manager->persist($child);
+
+        $sub = new Page();
+        $sub->setName('Sub Child page');
+        $sub->setSlug('sub-child-page');
+        $sub->setState(ThreeStateStatusEnum::PUBLISHED);
+        $sub->setParent($child);
+        $manager->persist($sub);
+
+        $manager->flush();
+    }
+}

--- a/tests/FixturesTrait.php
+++ b/tests/FixturesTrait.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\Persistence\ManagerRegistry;
+
+trait FixturesTrait
+{
+    private function loadFixtures(array $fixtures): void
+    {
+        /** @var ManagerRegistry $registry */
+        $registry = self::getContainer()->get('doctrine');
+        $em = $registry->getManager();
+
+        $loader = new Loader();
+        foreach ($fixtures as $fixture) {
+            $loader->addFixture($fixture);
+        }
+        $purger = new ORMPurger($em);
+        $executor = new ORMExecutor($em, $purger);
+        $executor->execute($loader->getFixtures(), true);
+    }
+}

--- a/tests/PageLoadTest.php
+++ b/tests/PageLoadTest.php
@@ -3,33 +3,42 @@ declare(strict_types=1);
 
 namespace App\Tests;
 
+use App\Tests\Fixtures\PageFixtures;
+use App\Tests\FixturesTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class PageLoadTest extends WebTestCase
 {
+    use FixturesTrait;
+
+    private \Symfony\Bundle\FrameworkBundle\KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client = static::createClient();
+        $this->loadFixtures([new PageFixtures()]);
+    }
     public function testHomepageLoads(): void
     {
-        $client = static::createClient();
-        $client->followRedirects(true);
-        $client->request('GET', '/');
+        $this->client->followRedirects(true);
+        $this->client->request('GET', '/');
 
         self::assertResponseIsSuccessful();
     }
 
     public function testChildPageLoads(): void
     {
-        $client = static::createClient();
-        $client->followRedirects(true);
-        $client->request('GET', '/child-page/');
+        $this->client->followRedirects(true);
+        $this->client->request('GET', '/child-page/');
 
         self::assertResponseIsSuccessful();
     }
 
     public function testSubChildPageLoads(): void
     {
-        $client = static::createClient();
-        $client->followRedirects(true);
-        $client->request('GET', '/child-page/sub-child-page/');
+        $this->client->followRedirects(true);
+        $this->client->request('GET', '/child-page/sub-child-page/');
 
         self::assertResponseIsSuccessful();
     }


### PR DESCRIPTION
## Summary
- provide fixtures to create FAQ and Page entities
- add a helper trait to load Doctrine fixtures in tests
- cover EasyFaq bundle with controller, repository, routing and listener tests
- ensure page tests load minimal fixtures

## Testing
- `./vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_684438538f8483239da64b4d881b0420