### PR TITLE
Add tests for EasyBlock bundle

### DIFF
--- a/tests/EasyBlockBundle/Admin/BlockSettingsFieldTest.php
+++ b/tests/EasyBlockBundle/Admin/BlockSettingsFieldTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Admin;
+
+use Adeliom\EasyBlockBundle\Admin\Field\BlockSettingsField;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use PHPUnit\Framework\TestCase;
+
+class BlockSettingsFieldTest extends TestCase
+{
+    public function testNewCreatesFieldWithDefaults(): void
+    {
+        $field = BlockSettingsField::new('settings', 'Settings');
+        $dto = $field->getAsDto();
+
+        $this->assertSame('settings', $dto->getProperty());
+        $this->assertSame('Settings', $dto->getLabel());
+        $this->assertFalse($dto->isDisplayedOn(Crud::PAGE_INDEX));
+        $this->assertSame('', $dto->getDefaultColumns());
+    }
+}

--- a/tests/EasyBlockBundle/Block/AbstractBlockTest.php
+++ b/tests/EasyBlockBundle/Block/AbstractBlockTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Block;
+
+use App\Tests\EasyBlockBundle\Fixtures\DummyBlockType;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Forms;
+
+class AbstractBlockTest extends TestCase
+{
+    public function testBuildFormAddsHiddenFields(): void
+    {
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $blockType = new DummyBlockType($manager);
+        $factory = Forms::createFormFactory();
+        $builder = $factory->createBuilder();
+        $blockType->buildForm($builder, []);
+        $form = $builder->getForm();
+
+        $this->assertTrue($form->has('block_type'));
+        $this->assertTrue($form->has('position'));
+    }
+}

--- a/tests/EasyBlockBundle/Block/BlockCollectionTest.php
+++ b/tests/EasyBlockBundle/Block/BlockCollectionTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Block;
+
+use Adeliom\EasyBlockBundle\Block\BlockCollection;
+use App\Tests\EasyBlockBundle\Fixtures\DummyBlockType;
+use Doctrine\ORM\EntityManagerInterface;
+use App\Tests\EasyBlockBundle\Fixtures\AnotherDummyBlockType;
+use PHPUnit\Framework\TestCase;
+
+class BlockCollectionTest extends TestCase
+{
+    public function testBlocksAreIndexedByClass(): void
+    {
+        $manager = $this->createStub(EntityManagerInterface::class);
+        $alpha = new DummyBlockType($manager);
+        $omega = new AnotherDummyBlockType($manager);
+
+        $collection = new BlockCollection([$alpha, $omega]);
+
+        $blocks = $collection->getBlocks();
+        $this->assertArrayHasKey(AnotherDummyBlockType::class, $blocks);
+        $this->assertSame($omega, $blocks[AnotherDummyBlockType::class]);
+        $this->assertArrayHasKey(DummyBlockType::class, $blocks);
+        $this->assertSame($alpha, $blocks[DummyBlockType::class]);
+    }
+}

--- a/tests/EasyBlockBundle/Block/HelperTest.php
+++ b/tests/EasyBlockBundle/Block/HelperTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Block;
+
+use Adeliom\EasyBlockBundle\Block\BlockCollection;
+use Adeliom\EasyBlockBundle\Block\Helper;
+use App\Tests\EasyBlockBundle\Fixtures\DummyBlockType;
+use App\Entity\EasyBlock\Block;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Forms;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class HelperTest extends TestCase
+{
+    public function testRenderEasyBlockAndIncludeAssets(): void
+    {
+        $twig = new Environment(new ArrayLoader(['dummy.html.twig' => '{{ block.key }}']));
+        $dispatcher = new EventDispatcher();
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $repository = $this->createMock(\Doctrine\Persistence\ObjectRepository::class);
+        $block = new Block();
+        $block->setName('b');
+        $block->setKey('alpha-key');
+        $block->setType(DummyBlockType::class);
+        $block->setStatus(true);
+        $block->setSettings(['name' => 'Alpha']);
+        $repository->method('find')->willReturn($block);
+        $manager->method('getRepository')->willReturn($repository);
+
+        $blockType = new DummyBlockType($manager);
+        $collection = new BlockCollection([$blockType]);
+
+        $helper = new class($twig, $dispatcher, $collection, $manager, Block::class, Forms::createFormFactory()) extends Helper {
+            public function transformSettingsWithBlockTypeFormBuild($blockType, $block, $defaultSetting)
+            {
+                return array_merge($defaultSetting, $block->getSettings());
+            }
+        };
+
+        $result = $helper->renderEasyBlock($twig, [], ['class' => Block::class, 'id' => 1]);
+        $this->assertSame('alpha-key', (string) $result);
+
+        $assets = $helper->includeAssets();
+        $this->assertStringContainsString('<script', $assets);
+    }
+}

--- a/tests/EasyBlockBundle/Controller/BlockCrudControllerTest.php
+++ b/tests/EasyBlockBundle/Controller/BlockCrudControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Controller;
+
+use Adeliom\EasyBlockBundle\Block\BlockCollection;
+use Adeliom\EasyBlockBundle\Controller\BlockCrudController;
+use PHPUnit\Framework\TestCase;
+
+class BlockCrudControllerTest extends TestCase
+{
+    public function testSubscribedServicesContainsBlockCollection(): void
+    {
+        $services = BlockCrudController::getSubscribedServices();
+        $this->assertArrayHasKey('easy_block.block_collection', $services);
+        $this->assertSame('?' . BlockCollection::class, $services['easy_block.block_collection']);
+    }
+}

--- a/tests/EasyBlockBundle/DataCollector/BlockCollectorTest.php
+++ b/tests/EasyBlockBundle/DataCollector/BlockCollectorTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\DataCollector;
+
+use Adeliom\EasyBlockBundle\Block\Helper;
+use Adeliom\EasyBlockBundle\DataCollector\BlockCollector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class BlockCollectorTest extends TestCase
+{
+    public function testCollectStoresBlocks(): void
+    {
+        $helper = $this->createMock(Helper::class);
+        $helper->method('getTraces')->willReturn(['foo']);
+
+        $collector = new BlockCollector($helper);
+        $collector->collect(new Request(), new Response());
+
+        $this->assertSame(['foo'], $collector->getBlocks());
+        $this->assertSame(BlockCollector::class, $collector->getName());
+    }
+}

--- a/tests/EasyBlockBundle/Editor/SharedBlockTypeTest.php
+++ b/tests/EasyBlockBundle/Editor/SharedBlockTypeTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Editor;
+
+use Adeliom\EasyBlockBundle\Editor\SharedBlockType;
+use App\Tests\EasyBlockBundle\Fixtures\DummyTranslator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class SharedBlockTypeTest extends TestCase
+{
+    public function testBuildBlockAddsEntityField(): void
+    {
+        $em = $this->createStub(EntityManagerInterface::class);
+        $translator = new DummyTranslator();
+        $type = new SharedBlockType($em, $translator, 'App\\Entity\\EasyBlock\\Block');
+
+        $builder = $this->createMock(\Symfony\Component\Form\FormBuilderInterface::class);
+        $builder->expects($this->once())
+            ->method('add')
+            ->with('block', \Symfony\Bridge\Doctrine\Form\Type\EntityType::class, $this->arrayHasKey('class'))
+            ->willReturnSelf();
+        $type->buildBlock($builder, []);
+
+        $this->assertSame('easy.block.editor.shared_block', $type->getName());
+        $this->assertSame('<span class="fas fa-shapes"></span>', $type->getIcon());
+    }
+}

--- a/tests/EasyBlockBundle/Event/EventTest.php
+++ b/tests/EasyBlockBundle/Event/EventTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Event;
+
+use Adeliom\EasyBlockBundle\Event\BlockEvent;
+use Adeliom\EasyBlockBundle\Event\ParseBlockEvent;
+use Adeliom\EasyBlockBundle\Event\PostBlockEvent;
+use Adeliom\EasyBlockBundle\Event\PreBlockEvent;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+
+class EventTest extends TestCase
+{
+    public function testParseBlockEvent(): void
+    {
+        $event = new ParseBlockEvent(['foo' => ['bar']]);
+        $this->assertSame(['foo' => ['bar']], $event->getSettings());
+        $this->assertSame(['bar'], $event->getSetting('foo'));
+    }
+
+    public function testPostBlockEvent(): void
+    {
+        $event = new PostBlockEvent('content');
+        $this->assertSame('content', $event->getContent());
+    }
+
+    public function testPreBlockEvent(): void
+    {
+        $collection = new ArrayCollection();
+        $event = new PreBlockEvent($collection);
+        $this->assertSame($collection, $event->getBlocks());
+    }
+
+    public function testBlockEventIsSubclass(): void
+    {
+        $event = new BlockEvent();
+        $this->assertInstanceOf(BlockEvent::class, $event);
+    }
+}

--- a/tests/EasyBlockBundle/Fixtures/AnotherDummyBlockType.php
+++ b/tests/EasyBlockBundle/Fixtures/AnotherDummyBlockType.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class AnotherDummyBlockType extends DummyBlockType
+{
+    public function __construct(EntityManagerInterface $manager)
+    {
+        parent::__construct($manager);
+    }
+
+    public function getName(): string
+    {
+        return 'Another Dummy';
+    }
+}

--- a/tests/EasyBlockBundle/Fixtures/DummyBlockType.php
+++ b/tests/EasyBlockBundle/Fixtures/DummyBlockType.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Fixtures;
+
+use Adeliom\EasyBlockBundle\Block\AbstractBlock;
+use Adeliom\EasyBlockBundle\Block\BlockInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DummyBlockType extends AbstractBlock implements BlockInterface
+{
+    public function __construct(EntityManagerInterface $manager)
+    {
+        parent::__construct($manager);
+    }
+
+    public function buildBlock(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class);
+    }
+
+    public function getName(): string
+    {
+        return 'Dummy';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Dummy block';
+    }
+
+    public function getIcon(): string
+    {
+        return '<i>dummy</i>';
+    }
+
+    public function getTemplate(): string
+    {
+        return 'dummy.html.twig';
+    }
+
+    public static function configureAssets(): array
+    {
+        return [
+            'js' => ['dummy.js'],
+            'css' => [],
+            'webpack' => [],
+        ];
+    }
+
+    public static function getDefaultSettings(): array
+    {
+        return ['name' => 'Default'];
+    }
+}

--- a/tests/EasyBlockBundle/Fixtures/DummyTranslator.php
+++ b/tests/EasyBlockBundle/Fixtures/DummyTranslator.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Fixtures;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DummyTranslator implements TranslatorInterface
+{
+    public function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+    {
+        return $id;
+    }
+
+    public function getLocale(): string
+    {
+        return 'en';
+    }
+}

--- a/tests/EasyBlockBundle/Fixtures/TestBlockFixtures.php
+++ b/tests/EasyBlockBundle/Fixtures/TestBlockFixtures.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Fixtures;
+
+use App\Entity\EasyBlock\Block;
+use App\Tests\EasyBlockBundle\Fixtures\DummyBlockType;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class TestBlockFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $block1 = new Block();
+        $block1->setName('Alpha Block');
+        $block1->setKey('alpha-key');
+        $block1->setType(DummyBlockType::class);
+        $block1->setStatus(true);
+        $block1->setSettings(['name' => 'Alpha']);
+        $manager->persist($block1);
+
+        $block2 = new Block();
+        $block2->setName('Omega Block');
+        $block2->setKey('omega-key');
+        $block2->setType(DummyBlockType::class);
+        $block2->setStatus(false);
+        $block2->setSettings(['name' => 'Omega']);
+        $manager->persist($block2);
+
+        $manager->flush();
+    }
+}

--- a/tests/EasyBlockBundle/Maker/MakeSharedBlockTest.php
+++ b/tests/EasyBlockBundle/Maker/MakeSharedBlockTest.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Maker;
+
+use Adeliom\EasyBlockBundle\Maker\MakeSharedBlock;
+use PHPUnit\Framework\TestCase;
+
+class MakeSharedBlockTest extends TestCase
+{
+    public function testCommandNameAndDescription(): void
+    {
+        $maker = new MakeSharedBlock();
+        $this->assertSame('make:block:shared', $maker->getCommandName());
+        $this->assertNotEmpty($maker->getCommandDescription());
+    }
+}

--- a/tests/EasyBlockBundle/Repository/BlockRepositoryTest.php
+++ b/tests/EasyBlockBundle/Repository/BlockRepositoryTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Repository;
+
+use App\Entity\EasyBlock\Block;
+use App\Repository\EasyBlock\BlockRepository;
+use App\Tests\EasyBlockBundle\Fixtures\DummyBlockType;
+use App\Tests\EasyBlockBundle\Fixtures\TestBlockFixtures;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class BlockRepositoryTest extends KernelTestCase
+{
+    public function testRepositoryQueries(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $em = $container->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->dropSchema([$em->getClassMetadata(Block::class)]);
+        $schemaTool->createSchema([$em->getClassMetadata(Block::class)]);
+
+        $fixture = new TestBlockFixtures();
+        $fixture->load($em);
+
+        /** @var BlockRepository $repo */
+        $repo = $em->getRepository(Block::class);
+
+        $this->assertCount(1, $repo->getActive());
+        $this->assertCount(1, $repo->getByType(DummyBlockType::class));
+    }
+}

--- a/tests/EasyBlockBundle/Twig/EasyBlockExtensionTest.php
+++ b/tests/EasyBlockBundle/Twig/EasyBlockExtensionTest.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyBlockBundle\Twig;
+
+use Adeliom\EasyBlockBundle\Block\Helper;
+use Adeliom\EasyBlockBundle\Twig\EasyBlockExtension;
+use PHPUnit\Framework\TestCase;
+
+class EasyBlockExtensionTest extends TestCase
+{
+    public function testFunctionsAreRegistered(): void
+    {
+        $helper = $this->createMock(Helper::class);
+        $extension = new EasyBlockExtension($helper);
+        $functions = $extension->getFunctions();
+
+        $names = array_map(static fn($f) => $f->getName(), $functions);
+        $this->assertContains('easy_block', $names);
+        $this->assertContains('easy_block_assets', $names);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit tests for EasyBlockBundle classes
- create fixture block types and entities for testing

## Testing
- `php -d zend.enable_gc=0 ./vendor/bin/phpunit --testsuite "Project Test Suite"`

------
https://chatgpt.com/codex/tasks/task_e_68443d2597a48323add329e19e18627c