### PR TITLE
Add tests for EasyEditorBundle

### DIFF
--- a/tests/EasyEditorBundle/Admin/EasyEditorFieldTest.php
+++ b/tests/EasyEditorBundle/Admin/EasyEditorFieldTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Admin;
+
+use Adeliom\EasyEditorBundle\Admin\Field\EasyEditorField;
+use PHPUnit\Framework\TestCase;
+
+final class EasyEditorFieldTest extends TestCase
+{
+    public function testDefaultOptions(): void
+    {
+        $field = EasyEditorField::new('content');
+        $dto = $field->getAsDto();
+
+        self::assertTrue($dto->getCustomOption(EasyEditorField::OPTION_ALLOW_DRAG));
+        self::assertTrue($dto->getCustomOption(EasyEditorField::OPTION_ALLOW_ADD));
+        self::assertTrue($dto->getCustomOption(EasyEditorField::OPTION_ALLOW_DELETE));
+        self::assertFalse($dto->getCustomOption(EasyEditorField::OPTION_SHOW_ENTRY_LABEL));
+        self::assertFalse($dto->getCustomOption(EasyEditorField::OPTION_RENDER_EXPANDED));
+    }
+}

--- a/tests/EasyEditorBundle/Block/BlockCollectionTest.php
+++ b/tests/EasyEditorBundle/Block/BlockCollectionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Block;
+
+use Adeliom\EasyEditorBundle\Block\BlockCollection;
+use App\Tests\EasyEditorBundle\Fixtures\DummyBlock;
+use App\Tests\EasyEditorBundle\Fixtures\Entity\DummyEntity;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use PHPUnit\Framework\TestCase;
+
+final class BlockCollectionTest extends TestCase
+{
+    private function createBlock(string $template, int $position, bool $supports = true): DummyBlock
+    {
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $block = new class($manager, $template, $position, $supports) extends DummyBlock {
+            public function __construct(EntityManagerInterface $manager, private string $tpl, private int $pos, private bool $supportsFlag)
+            {
+                parent::__construct($manager);
+            }
+            public function getTemplate(): string
+            {
+                return $this->tpl;
+            }
+            public function getPosition(): int
+            {
+                return $this->pos;
+            }
+            public function supports(string $objectClass, ?object $instance = null): bool
+            {
+                return $this->supportsFlag;
+            }
+        };
+        return $block;
+    }
+
+    public function testGetAllowedBlocksFiltersByType(): void
+    {
+        $blockA = $this->createBlock('a.html.twig', 2);
+        $blockB = $this->createBlock('b.html.twig', 1);
+        $collection = new BlockCollection([$blockA, $blockB]);
+
+        $allowed = $collection->getAllowedBlocks([$blockA::class]);
+        self::assertCount(1, $allowed);
+    }
+
+    public function testEnabledSupportFilterRemovesUnsupportedBlocks(): void
+    {
+        $supported = $this->createBlock('a.html.twig', 1, true);
+        $collection = new BlockCollection([$supported]);
+
+        $metadata = new ClassMetadata(DummyEntity::class);
+        $metadata->setIdentifier(['id']);
+        $dto = new EntityDto(DummyEntity::class, $metadata, null, new DummyEntity());
+        $result = $collection->enabledSupportFilter($dto);
+
+        self::assertSame($collection, $result);
+    }
+}

--- a/tests/EasyEditorBundle/Block/HelperTest.php
+++ b/tests/EasyEditorBundle/Block/HelperTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Block;
+
+use Adeliom\EasyEditorBundle\Block\BlockCollection;
+use Adeliom\EasyEditorBundle\Block\Helper;
+use App\Tests\EasyEditorBundle\Fixtures\DummyBlock;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\Forms;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class HelperTest extends TestCase
+{
+    public function testRenderBlockReturnsMarkup(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'dummy.html.twig' => '<div id="{{ settings.attr_id }}">dummy</div>',
+        ]));
+        $dispatcher = new EventDispatcher();
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $block = new DummyBlock($manager);
+        $collection = new BlockCollection([$block]);
+        $formFactory = Forms::createFormFactoryBuilder()->getFormFactory();
+        $helper = new Helper($twig, $dispatcher, $collection, $formFactory, $manager);
+
+        $markup = $helper->renderEasyEditorBlock($twig, [], ['block_type' => $block::class, 'position' => 1]);
+
+        self::assertStringContainsString('dummy', (string) $markup);
+        self::assertNotEmpty($helper->getTraces());
+        self::assertIsString($helper->includeAssets());
+    }
+}

--- a/tests/EasyEditorBundle/DataCollector/EditorCollectorTest.php
+++ b/tests/EasyEditorBundle/DataCollector/EditorCollectorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\DataCollector;
+
+use Adeliom\EasyEditorBundle\Block\BlockCollection;
+use Adeliom\EasyEditorBundle\Block\Helper;
+use Adeliom\EasyEditorBundle\DataCollector\EditorCollector;
+use App\Tests\EasyEditorBundle\Fixtures\DummyBlock;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\Forms;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class EditorCollectorTest extends TestCase
+{
+    public function testCollectStoresBlockTraces(): void
+    {
+        $twig = new Environment(new ArrayLoader([
+            'dummy.html.twig' => 'dummy',
+        ]));
+        $dispatcher = new EventDispatcher();
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $block = new DummyBlock($manager);
+        $collection = new BlockCollection([$block]);
+        $formFactory = Forms::createFormFactoryBuilder()->getFormFactory();
+        $helper = new Helper($twig, $dispatcher, $collection, $formFactory, $manager);
+        $helper->renderEasyEditorBlock($twig, [], ['block_type' => $block::class]);
+
+        $collector = new EditorCollector($helper);
+        $collector->collect(new Request(), new Response());
+
+        self::assertNotEmpty($collector->getBlocks());
+        self::assertSame(EditorCollector::class, $collector->getName());
+    }
+}

--- a/tests/EasyEditorBundle/EventListener/ResizeFormListenerTest.php
+++ b/tests/EasyEditorBundle/EventListener/ResizeFormListenerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\EventListener;
+
+use Adeliom\EasyEditorBundle\EventListener\ResizeFormListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\Forms;
+
+final class ResizeFormListenerTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $events = ResizeFormListener::getSubscribedEvents();
+        self::assertArrayHasKey('form.pre_set_data', $events);
+        self::assertArrayHasKey('form.pre_submit', $events);
+        self::assertArrayHasKey('form.submit', $events);
+    }
+
+    public function testOnSubmitSortsByPosition(): void
+    {
+        $factory = Forms::createFormFactory();
+        $form = $factory->createBuilder(CollectionType::class, [
+            ['block_type' => TextType::class, 'position' => 2],
+            ['block_type' => TextType::class, 'position' => 1],
+        ], [
+            'entry_type' => TextType::class,
+        ])->getForm();
+
+        $listener = new ResizeFormListener(TextType::class, [], true, true);
+        $event = new FormEvent($form, $form->getData());
+        $listener->onSubmit($event);
+
+        $data = $event->getData();
+        self::assertSame(1, $data[0]['position']);
+        self::assertSame(2, $data[1]['position']);
+    }
+}

--- a/tests/EasyEditorBundle/Fixtures/DummyBlock.php
+++ b/tests/EasyEditorBundle/Fixtures/DummyBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Fixtures;
+
+use Adeliom\EasyEditorBundle\Block\AbstractBlock;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class DummyBlock extends AbstractBlock
+{
+    public function __construct(EntityManagerInterface $manager)
+    {
+        parent::__construct($manager);
+    }
+
+    public function buildBlock(FormBuilderInterface $builder, array $options): void
+    {
+        // no custom fields
+    }
+
+    public function getName(): string
+    {
+        return 'Dummy';
+    }
+
+    public function getIcon(): string
+    {
+        return '<i class="dummy"></i>';
+    }
+
+    public function getTemplate(): string
+    {
+        return 'dummy.html.twig';
+    }
+}

--- a/tests/EasyEditorBundle/Fixtures/Entity/DummyEntity.php
+++ b/tests/EasyEditorBundle/Fixtures/Entity/DummyEntity.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class DummyEntity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $name = '';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/EasyEditorBundle/Form/EditorCollectionTypeTest.php
+++ b/tests/EasyEditorBundle/Form/EditorCollectionTypeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Form;
+
+use Adeliom\EasyEditorBundle\Block\BlockCollection;
+use Adeliom\EasyEditorBundle\Form\EditorCollectionType;
+use App\Tests\EasyEditorBundle\Fixtures\DummyBlock;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class EditorCollectionTypeTest extends TestCase
+{
+    public function testConfigureOptionsSetsDefaults(): void
+    {
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $block = new DummyBlock($manager);
+        $collection = new BlockCollection([$block]);
+        $type = new EditorCollectionType($collection);
+
+        $resolver = new OptionsResolver();
+        $type->configureOptions($resolver);
+        $options = $resolver->resolve();
+
+        self::assertArrayHasKey('blocks', $options);
+        self::assertTrue($options['allow_extra_fields']);
+        self::assertFalse($options['allow_drag']);
+    }
+}

--- a/tests/EasyEditorBundle/Maker/MakeBlockTest.php
+++ b/tests/EasyEditorBundle/Maker/MakeBlockTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Maker;
+
+use Adeliom\EasyEditorBundle\Maker\MakeBlock;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+
+final class MakeBlockTest extends TestCase
+{
+    public function testCommandBasics(): void
+    {
+        self::assertSame('make:block', MakeBlock::getCommandName());
+        self::assertSame('Creates a new block type', MakeBlock::getCommandDescription());
+
+        $maker = new MakeBlock();
+        $command = new Command('test');
+        $maker->configureCommand($command, new InputConfiguration());
+
+        $definition = $command->getDefinition();
+        self::assertTrue($definition->hasArgument('block-type'));
+    }
+}

--- a/tests/EasyEditorBundle/Twig/EasyBlockExtensionTest.php
+++ b/tests/EasyEditorBundle/Twig/EasyBlockExtensionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyEditorBundle\Twig;
+
+use Adeliom\EasyEditorBundle\Twig\EasyBlockExtension;
+use PHPUnit\Framework\TestCase;
+use Twig\TwigFunction;
+
+final class EasyBlockExtensionTest extends TestCase
+{
+    public function testFunctions(): void
+    {
+        $ext = new EasyBlockExtension();
+        $functions = $ext->getFunctions();
+        self::assertCount(2, $functions);
+        self::assertContainsOnlyInstancesOf(TwigFunction::class, $functions);
+        self::assertSame('easy_editor_block', $functions[0]->getName());
+        self::assertSame('easy_editor_assets', $functions[1]->getName());
+    }
+}


### PR DESCRIPTION
## Summary
- add dummy entity and block for tests
- cover EasyEditor bundle classes with PHPUnit tests

## Testing
- `php bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68443de6cb148323b4156ac6c71e0a67