### PR TITLE
Add tests for EasyFields bundle

### DIFF
--- a/tests/EasyFieldsBundle/Admin/AssociationFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/AssociationFieldTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\AssociationField;
+use PHPUnit\Framework\TestCase;
+
+class AssociationFieldTest extends TestCase
+{
+    public function testAllowAdd(): void
+    {
+        $field = AssociationField::new('prop');
+        $field->allowAdd();
+        $this->assertTrue($field->getAsDto()->getCustomOption(AssociationField::OPTION_ALLOW_ADD));
+    }
+
+    public function testListDisplayColumns(): void
+    {
+        $field = AssociationField::new('prop');
+        $field->listDisplayColumns(2);
+        $option = $field->getAsDto()->getCustomOption(AssociationField::OPTION_LIST_DISPLAY_COLUMNS);
+        $this->assertSame(['columns' => [2], 'separator' => '-'], $option);
+    }
+}

--- a/tests/EasyFieldsBundle/Admin/ChoiceMaskFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/ChoiceMaskFieldTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\ChoiceMaskField;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ChoiceMaskFieldTest extends TestCase
+{
+    public function testSetChoicesWithInvalidType(): void
+    {
+        $field = ChoiceMaskField::new('choice');
+        $this->expectException(InvalidArgumentException::class);
+        $field->setChoices('invalid');
+    }
+
+    public function testRenderAsBadgesWithInvalidBadgeType(): void
+    {
+        $field = ChoiceMaskField::new('choice');
+        $this->expectException(InvalidArgumentException::class);
+        $field->renderAsBadges(['foo' => 'invalid']);
+    }
+}

--- a/tests/EasyFieldsBundle/Admin/FormTypeFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/FormTypeFieldTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\FormTypeField;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use PHPUnit\Framework\TestCase;
+
+class FormTypeFieldTest extends TestCase
+{
+    public function testFormType(): void
+    {
+        $field = FormTypeField::new('email', 'Email', EmailType::class);
+        $this->assertSame(EmailType::class, $field->getAsDto()->getFormType());
+    }
+}

--- a/tests/EasyFieldsBundle/Admin/IconFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/IconFieldTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\IconField;
+use PHPUnit\Framework\TestCase;
+
+class IconFieldTest extends TestCase
+{
+    public function testSetRequired(): void
+    {
+        $field = IconField::new('icon');
+        $field->setRequired(false);
+        $this->assertFalse($field->getAsDto()->getFormTypeOption('required'));
+    }
+}

--- a/tests/EasyFieldsBundle/Admin/OembedFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/OembedFieldTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\OembedField;
+use PHPUnit\Framework\TestCase;
+
+class OembedFieldTest extends TestCase
+{
+    public function testTemplatePath(): void
+    {
+        $field = OembedField::new('oembed');
+        $this->assertSame('@EasyFields/crud/field/oembed.html.twig', $field->getAsDto()->getTemplatePath());
+    }
+}

--- a/tests/EasyFieldsBundle/Admin/PositionSortableFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/PositionSortableFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\PositionSortableField;
+use PHPUnit\Framework\TestCase;
+
+class PositionSortableFieldTest extends TestCase
+{
+    public function testParentProperty(): void
+    {
+        $field = PositionSortableField::new('position');
+        $this->assertSame('parent', $field->getAsDto()->getCustomOption(PositionSortableField::PARENT_PROPERTY));
+        $field->setParentProperty('section');
+        $this->assertSame('section', $field->getAsDto()->getCustomOption(PositionSortableField::PARENT_PROPERTY));
+    }
+}

--- a/tests/EasyFieldsBundle/Admin/SortableCollectionFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/SortableCollectionFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\SortableCollectionField;
+use PHPUnit\Framework\TestCase;
+
+class SortableCollectionFieldTest extends TestCase
+{
+    public function testAllowAdd(): void
+    {
+        $field = SortableCollectionField::new('collection');
+        $this->assertTrue($field->getAsDto()->getCustomOption(SortableCollectionField::OPTION_ALLOW_ADD));
+        $field->allowAdd(false);
+        $this->assertFalse($field->getAsDto()->getCustomOption(SortableCollectionField::OPTION_ALLOW_ADD));
+    }
+}

--- a/tests/EasyFieldsBundle/Admin/TranslationFieldTest.php
+++ b/tests/EasyFieldsBundle/Admin/TranslationFieldTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Admin;
+
+use Adeliom\EasyFieldsBundle\Admin\Field\TranslationField;
+use PHPUnit\Framework\TestCase;
+
+class TranslationFieldTest extends TestCase
+{
+    public function testHideOnIndex(): void
+    {
+        $field = TranslationField::new('translation');
+        $this->assertTrue($field->getAsDto()->getDisplayedOn()->has('edit'));
+        $this->assertTrue($field->getAsDto()->getDisplayedOn()->has('new'));
+    }
+}

--- a/tests/EasyFieldsBundle/Controller/OembedControllerTest.php
+++ b/tests/EasyFieldsBundle/Controller/OembedControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Controller;
+
+use Adeliom\EasyFieldsBundle\Controller\OembedController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
+
+class OembedControllerTest extends TestCase
+{
+    public function testIndexWithMissingUrl(): void
+    {
+        $controller = new OembedController();
+        $this->expectException(BadRequestException::class);
+        $controller->index(new Request());
+    }
+
+    public function testIndexWithInvalidUrl(): void
+    {
+        $controller = new OembedController();
+        $this->expectException(BadRequestException::class);
+        $controller->index(new Request(['url' => 'invalid']));
+    }
+}

--- a/tests/EasyFieldsBundle/EventListener/AdminListenerTest.php
+++ b/tests/EasyFieldsBundle/EventListener/AdminListenerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\EventListener;
+
+use Adeliom\EasyFieldsBundle\EventListener\AdminListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class DummyKernel implements HttpKernelInterface
+{
+    public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+    {
+        return new Response();
+    }
+}
+
+class AdminListenerTest extends TestCase
+{
+    public function testHeadersAreAdded(): void
+    {
+        $listener = new AdminListener();
+        $request = new Request(['crudAction' => 'edit', 'crudControllerFqcn' => 'App\\Controller']);
+        $response = new Response();
+        $event = new ResponseEvent(new DummyKernel(), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        $listener->onKernelResponse($event);
+        $this->assertSame('edit', $response->headers->get('X-CRUD-ACTION'));
+        $this->assertSame('App\\Controller', $response->headers->get('X-CRUD-CONTROLLER'));
+    }
+}

--- a/tests/EasyFieldsBundle/Form/ChoiceMaskTypeTest.php
+++ b/tests/EasyFieldsBundle/Form/ChoiceMaskTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Form;
+
+use Adeliom\EasyFieldsBundle\Form\ChoiceMaskType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormInterface;
+
+class ChoiceMaskTypeTest extends TestCase
+{
+    public function testBuildViewSanitize(): void
+    {
+        $type = new ChoiceMaskType();
+        $view = new FormView();
+        $form = $this->createMock(FormInterface::class);
+        $type->buildView($view, $form, ['map' => ['v' => ['foo.bar', 'bar__foo']]]);
+        $this->assertSame(['v' => ['foo__bar', 'bar____foo']], $view->vars['map']);
+        $this->assertSame(['foo__bar', 'bar____foo'], $view->vars['all_fields']);
+    }
+}

--- a/tests/EasyFieldsBundle/Form/CollectionTypeExtensionTest.php
+++ b/tests/EasyFieldsBundle/Form/CollectionTypeExtensionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Form;
+
+use Adeliom\EasyFieldsBundle\Form\Extension\CollectionTypeExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CollectionTypeExtensionTest extends TestCase
+{
+    public function testConfigureOptions(): void
+    {
+        $resolver = new OptionsResolver();
+        (new CollectionTypeExtension())->configureOptions($resolver);
+        $options = $resolver->resolve();
+        $this->assertFalse($options['sortable']);
+        $this->assertSame('form.collection.add', $options['button_add_label']);
+    }
+}

--- a/tests/EasyFieldsBundle/Form/EntityTypeExtensionTest.php
+++ b/tests/EasyFieldsBundle/Form/EntityTypeExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Form;
+
+use Adeliom\EasyFieldsBundle\Form\Extension\EntityTypeExtension;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistryInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EntityTypeExtensionTest extends TestCase
+{
+    public function testConfigureOptions(): void
+    {
+        $resolver = new OptionsResolver();
+        $adminUrlGenerator = new AdminUrlGenerator(
+            $this->createMock(AdminContextProviderInterface::class),
+            $this->createMock(UrlGeneratorInterface::class),
+            $this->createMock(DashboardControllerRegistryInterface::class),
+            $this->createMock(AdminRouteGeneratorInterface::class)
+        );
+        $extension = new EntityTypeExtension($adminUrlGenerator);
+        $extension->configureOptions($resolver);
+        $options = $resolver->resolve();
+        $this->assertFalse($options['allow_add']);
+        $this->assertSame('action.add_new_item', $options['button_add_label']);
+    }
+}

--- a/tests/EasyFieldsBundle/Form/FormTypeExtensionTest.php
+++ b/tests/EasyFieldsBundle/Form/FormTypeExtensionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Form;
+
+use Adeliom\EasyFieldsBundle\Form\Extension\FormTypeExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class FormTypeExtensionTest extends TestCase
+{
+    public function testConfigureOptions(): void
+    {
+        $resolver = new OptionsResolver();
+        (new FormTypeExtension())->configureOptions($resolver);
+        $options = $resolver->resolve();
+        $this->assertSame('', $options['column_size']);
+    }
+}

--- a/tests/EasyFieldsBundle/Form/IconTypeTest.php
+++ b/tests/EasyFieldsBundle/Form/IconTypeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Form;
+
+use Adeliom\EasyFieldsBundle\Form\IconType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class IconTypeTest extends TestCase
+{
+    public function testConfigureOptions(): void
+    {
+        $resolver = new OptionsResolver();
+        (new IconType())->configureOptions($resolver);
+        $options = $resolver->resolve();
+        $this->assertSame('Search Icon', $options['search_placeholder']);
+    }
+}

--- a/tests/EasyFieldsBundle/Form/OembedTypeTest.php
+++ b/tests/EasyFieldsBundle/Form/OembedTypeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Form;
+
+use Adeliom\EasyFieldsBundle\Form\OembedType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\UrlType;
+
+class OembedTypeTest extends TestCase
+{
+    public function testParent(): void
+    {
+        $this->assertSame(UrlType::class, (new OembedType())->getParent());
+    }
+}

--- a/tests/EasyFieldsBundle/Form/SortableCollectionTypeTest.php
+++ b/tests/EasyFieldsBundle/Form/SortableCollectionTypeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Form;
+
+use Adeliom\EasyFieldsBundle\Form\SortableCollectionType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class SortableCollectionTypeTest extends TestCase
+{
+    public function testDefaultOptions(): void
+    {
+        $resolver = new OptionsResolver();
+        (new SortableCollectionType())->configureOptions($resolver);
+        $options = $resolver->resolve();
+        $this->assertFalse($options['allow_drag']);
+        $this->assertSame('__name__', $options['prototype_name']);
+    }
+}

--- a/tests/EasyFieldsBundle/Traits/PositionSortableTraitTest.php
+++ b/tests/EasyFieldsBundle/Traits/PositionSortableTraitTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Traits;
+
+use Adeliom\EasyFieldsBundle\Traits\PositionSortableTrait;
+use PHPUnit\Framework\TestCase;
+
+class TestSortableEntity
+{
+    use PositionSortableTrait;
+}
+
+class PositionSortableTraitTest extends TestCase
+{
+    public function testGetSet(): void
+    {
+        $entity = new TestSortableEntity();
+        $entity->setLft(1);
+        $entity->setLvl(2);
+        $entity->setRgt(3);
+        $entity->setRoot(4);
+        $this->assertSame(1, $entity->getLft());
+        $this->assertSame(2, $entity->getLvl());
+        $this->assertSame(3, $entity->getRgt());
+        $this->assertSame(4, $entity->getRoot());
+        $this->assertSame(1, $entity->getSortableData('lft'));
+    }
+}

--- a/tests/EasyFieldsBundle/Twig/OembedExtensionTest.php
+++ b/tests/EasyFieldsBundle/Twig/OembedExtensionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EasyFieldsBundle\Twig;
+
+use Adeliom\EasyFieldsBundle\Twig\OembedExtension;
+use PHPUnit\Framework\TestCase;
+
+class OembedExtensionTest extends TestCase
+{
+    public function testInvalidUrlReturnsNull(): void
+    {
+        $ext = new OembedExtension();
+        $this->assertNull($ext->getCode('http://invalid')); 
+        $this->assertNull($ext->getDimensions('http://invalid')); 
+    }
+}

--- a/tests/Fixtures/ArticleFixture.php
+++ b/tests/Fixtures/ArticleFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Fixtures;
+
+use App\Entity\Article;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class ArticleFixture extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $article = new Article();
+        $article->setTitle('Test article');
+        $manager->persist($article);
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering EasyFields bundle classes
- include fixture for Article entity

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist`

------
https://chatgpt.com/codex/tasks/task_e_68443e0a9f848323b877c363cb25792a