### PR TITLE
Add tests for EasyMenu bundle

### DIFF
--- a/tests/EasyMenu/Controller/MenuCrudControllerTest.php
+++ b/tests/EasyMenu/Controller/MenuCrudControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\Controller;
+
+use Adeliom\EasyMenuBundle\Controller\MenuCrudController;
+use App\Entity\EasyMenu\Menu;
+use PHPUnit\Framework\TestCase;
+
+final class MenuCrudControllerTest extends TestCase
+{
+    public function testInformationsFieldsProvideNameAndCode(): void
+    {
+        $controller = new class() extends MenuCrudController {
+            public static function getEntityFqcn(): string
+            {
+                return Menu::class;
+            }
+        };
+
+        $fields = iterator_to_array($controller->informationsFields('new', null));
+
+        self::assertCount(3, $fields);
+        self::assertSame('name', $fields[1]->getAsDto()->getProperty());
+        self::assertSame('code', $fields[2]->getAsDto()->getProperty());
+    }
+}

--- a/tests/EasyMenu/Controller/MenuItemCrudControllerTest.php
+++ b/tests/EasyMenu/Controller/MenuItemCrudControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\Controller;
+
+use Adeliom\EasyMenuBundle\Controller\MenuItemCrudController;
+use App\Entity\EasyMenu\MenuItem;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class MenuItemCrudControllerTest extends TestCase
+{
+    public function testInformationsFieldsProvideName(): void
+    {
+        $controller = new class($this->createStub(ManagerRegistry::class)) extends MenuItemCrudController {
+            public static function getEntityFqcn(): string
+            {
+                return MenuItem::class;
+            }
+        };
+
+        $fields = iterator_to_array($controller->informationsFields('new', null));
+
+        self::assertSame('name', $fields[2]->getAsDto()->getProperty());
+        self::assertSame('parent', $fields[3]->getAsDto()->getProperty());
+    }
+}

--- a/tests/EasyMenu/DoctrineOrmTestCase.php
+++ b/tests/EasyMenu/DoctrineOrmTestCase.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+abstract class DoctrineOrmTestCase extends KernelTestCase
+{
+    protected EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+        $this->entityManager = self::getContainer()->get('doctrine')->getManager();
+        $schemaTool = new SchemaTool($this->entityManager);
+        $schemaTool->dropSchema($this->getMetadata());
+        $schemaTool->createSchema($this->getMetadata());
+    }
+
+    /**
+     * @return array<\Doctrine\ORM\Mapping\ClassMetadata>
+     */
+    abstract protected function getMetadata(): array;
+
+    protected function tearDown(): void
+    {
+        $this->entityManager->close();
+        parent::tearDown();
+    }
+}

--- a/tests/EasyMenu/EventListener/DoctrineMappingListenerTest.php
+++ b/tests/EasyMenu/EventListener/DoctrineMappingListenerTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\EventListener;
+
+use Adeliom\EasyMenuBundle\Entity\MenuEntity;
+use Adeliom\EasyMenuBundle\Entity\MenuItemEntity;
+use Adeliom\EasyMenuBundle\EventListener\DoctrineMappingListener;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PHPUnit\Framework\TestCase;
+
+final class DoctrineMappingListenerTest extends TestCase
+{
+    public function testRelationsAreAdded(): void
+    {
+        $listener = new DoctrineMappingListener(MenuEntity::class, MenuItemEntity::class);
+        $em = $this->createMock(\Doctrine\ORM\EntityManagerInterface::class);
+        $metadata = new ClassMetadata(MenuItemEntity::class);
+        $event = new LoadClassMetadataEventArgs($metadata, $em);
+
+        $listener->loadClassMetadata($event);
+
+        self::assertTrue($metadata->hasAssociation('menu'));
+        self::assertTrue($metadata->hasAssociation('parent'));
+        self::assertTrue($metadata->hasAssociation('children'));
+    }
+}

--- a/tests/EasyMenu/EventListener/MenuCreationListenerTest.php
+++ b/tests/EasyMenu/EventListener/MenuCreationListenerTest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\EventListener;
+
+use Adeliom\EasyMenuBundle\Entity\MenuEntity;
+use Adeliom\EasyMenuBundle\Entity\MenuItemEntity;
+use Adeliom\EasyMenuBundle\EventListener\MenuCreationListener;
+use PHPUnit\Framework\TestCase;
+
+final class MenuCreationListenerTest extends TestCase
+{
+    public function testPrePersistAddsRootItem(): void
+    {
+        $listener = new MenuCreationListener(MenuEntity::class, MenuItemEntity::class);
+        $menu = new class() extends MenuEntity {};
+
+        $listener->prePersist($menu);
+
+        self::assertCount(1, $menu->getItems());
+        $item = $menu->getItems()->first();
+        self::assertSame('Root', $item->getName());
+        self::assertSame($menu, $item->getMenu());
+    }
+}

--- a/tests/EasyMenu/Exceptions/MenuExceptionTest.php
+++ b/tests/EasyMenu/Exceptions/MenuExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\Exceptions;
+
+use Adeliom\EasyMenuBundle\Exceptions\MenuNotFoundException;
+use Adeliom\EasyMenuBundle\Exceptions\TemplateNotFoundException;
+use PHPUnit\Framework\TestCase;
+
+final class MenuExceptionTest extends TestCase
+{
+    public function testMenuNotFoundMessage(): void
+    {
+        $exception = new MenuNotFoundException('main');
+        self::assertSame('Could not find menu with code "main".', $exception->getMessage());
+    }
+
+    public function testTemplateNotFoundMessage(): void
+    {
+        $exception = new TemplateNotFoundException('missing.html.twig');
+        self::assertSame('Could not find template "missing.html.twig".', $exception->getMessage());
+    }
+}

--- a/tests/EasyMenu/Fixtures/MenuFixtures.php
+++ b/tests/EasyMenu/Fixtures/MenuFixtures.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\Fixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use App\Entity\EasyMenu\Menu;
+use App\Entity\EasyMenu\MenuItem;
+use Adeliom\EasyCommonBundle\Enum\ThreeStateStatusEnum;
+
+class MenuFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $menu = new Menu();
+        $menu->setCode('main');
+        $menu->setName('Main menu');
+        $menu->setStatus(true);
+
+        $item = new MenuItem();
+        $item->setName('Home');
+        $item->setUrl('/');
+        $item->setMenu($menu);
+        $item->setState(ThreeStateStatusEnum::PUBLISHED);
+        $menu->addItem($item);
+
+        $manager->persist($menu);
+        $manager->persist($item);
+        $manager->flush();
+    }
+}

--- a/tests/EasyMenu/Repository/MenuItemRepositoryTest.php
+++ b/tests/EasyMenu/Repository/MenuItemRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\Repository;
+
+use App\Entity\EasyMenu\Menu;
+use App\Entity\EasyMenu\MenuItem;
+use App\Tests\EasyMenu\DoctrineOrmTestCase;
+
+final class MenuItemRepositoryTest extends DoctrineOrmTestCase
+{
+    protected function getMetadata(): array
+    {
+        return [
+            $this->entityManager->getClassMetadata(Menu::class),
+            $this->entityManager->getClassMetadata(MenuItem::class),
+        ];
+    }
+
+    public function testSetConfigUpdatesProperties(): void
+    {
+        $repo = $this->entityManager->getRepository(MenuItem::class);
+        $repo->setConfig(['enabled' => true, 'ttl' => 1800]);
+
+        $ref = new \ReflectionClass($repo);
+        $enabled = $ref->getProperty('cacheEnabled');
+        $enabled->setAccessible(true);
+        $ttl = $ref->getProperty('cacheTtl');
+        $ttl->setAccessible(true);
+
+        self::assertTrue($enabled->getValue($repo));
+        self::assertSame(1800, $ttl->getValue($repo));
+    }
+}

--- a/tests/EasyMenu/Repository/MenuRepositoryTest.php
+++ b/tests/EasyMenu/Repository/MenuRepositoryTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\Repository;
+
+use App\Entity\EasyMenu\Menu;
+use App\Entity\EasyMenu\MenuItem;
+use App\Tests\EasyMenu\DoctrineOrmTestCase;
+
+final class MenuRepositoryTest extends DoctrineOrmTestCase
+{
+    protected function getMetadata(): array
+    {
+        return [
+            $this->entityManager->getClassMetadata(Menu::class),
+            $this->entityManager->getClassMetadata(MenuItem::class),
+        ];
+    }
+
+    public function testSetConfigUpdatesProperties(): void
+    {
+        $repo = $this->entityManager->getRepository(Menu::class);
+        $repo->setConfig(['enabled' => true, 'ttl' => 3600]);
+
+        $ref = new \ReflectionClass($repo);
+        $enabled = $ref->getProperty('cacheEnabled');
+        $enabled->setAccessible(true);
+        $ttl = $ref->getProperty('cacheTtl');
+        $ttl->setAccessible(true);
+
+        self::assertTrue($enabled->getValue($repo));
+        self::assertSame(3600, $ttl->getValue($repo));
+    }
+}

--- a/tests/EasyMenu/Twig/EasyMenuExtensionTest.php
+++ b/tests/EasyMenu/Twig/EasyMenuExtensionTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\EasyMenu\Twig;
+
+use Adeliom\EasyMenuBundle\Twig\EasyMenuExtension;
+use Adeliom\EasyMenuBundle\Exceptions\MenuNotFoundException;
+use Adeliom\EasyMenuBundle\Exceptions\TemplateNotFoundException;
+use App\Entity\EasyMenu\Menu;
+use App\Entity\EasyMenu\MenuItem;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class EasyMenuExtensionTest extends TestCase
+{
+    private function createRepository(Menu $menu): ObjectRepository
+    {
+        return new class($menu) implements ObjectRepository {
+            public function __construct(private Menu $menu) {}
+            public function find($id) {}
+            public function findAll() { return []; }
+            public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null) { return []; }
+            public function findOneBy(array $criteria) { return $this->menu; }
+            public function getClassName() { return Menu::class; }
+            public function findOneByCode(string $code) { return $this->menu; }
+        };
+    }
+
+    private function createItemRepository(MenuItem $item): ObjectRepository
+    {
+        return new class($item) implements ObjectRepository {
+            public function __construct(private MenuItem $item) {}
+            public function find($id) {}
+            public function findAll() { return []; }
+            public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null) { return []; }
+            public function findOneBy(array $criteria) { return $this->item; }
+            public function getClassName() { return MenuItem::class; }
+        };
+    }
+
+    private function createExtension(Menu $menu, MenuItem $rootItem, Environment $twig): EasyMenuExtension
+    {
+        $menuRepository = $this->createRepository($menu);
+        $itemRepository = $this->createItemRepository($rootItem);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturnMap([
+            [Menu::class, $menuRepository],
+            [MenuItem::class, $itemRepository],
+        ]);
+
+        return new EasyMenuExtension($twig, $em, Menu::class, MenuItem::class);
+    }
+
+    public function testRenderEasyMenuReturnsMarkup(): void
+    {
+        $menu = new Menu();
+        $menu->setCode('main');
+        $rootItem = new MenuItem();
+        $rootItem->setMenu($menu);
+
+        $twig = new Environment(new ArrayLoader([
+            '@EasyMenu/front/menus/main.html.twig' => 'Menu: {{ menu.code }}'
+        ]));
+        $extension = $this->createExtension($menu, $rootItem, $twig);
+
+        $markup = $extension->renderEasyMenu($twig, [], 'main');
+        self::assertSame('Menu: main', (string) $markup);
+    }
+
+    public function testCustomTemplate(): void
+    {
+        $menu = new Menu();
+        $menu->setCode('main');
+        $rootItem = new MenuItem();
+        $rootItem->setMenu($menu);
+
+        $twig = new Environment(new ArrayLoader([
+            '@EasyMenu/front/menus/main.html.twig' => 'unused',
+            'custom.html.twig' => 'Custom: {{ menu.code }}'
+        ]));
+        $extension = $this->createExtension($menu, $rootItem, $twig);
+        $markup = $extension->renderEasyMenu($twig, [], 'main', ['template' => 'custom.html.twig']);
+        self::assertSame('Custom: main', (string) $markup);
+    }
+
+    public function testMenuNotFoundThrowsException(): void
+    {
+        $menuRepository = new class implements ObjectRepository {
+            public function find($id) {}
+            public function findAll() { return []; }
+            public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null) { return []; }
+            public function findOneBy(array $criteria) { return null; }
+            public function getClassName() { return Menu::class; }
+            public function findOneByCode(string $code) { return null; }
+        };
+        $itemRepository = $this->createItemRepository(new MenuItem());
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturnMap([
+            [Menu::class, $menuRepository],
+            [MenuItem::class, $itemRepository],
+        ]);
+        $twig = new Environment(new ArrayLoader(['@EasyMenu/front/menus/main.html.twig' => '']));
+        $extension = new EasyMenuExtension($twig, $em, Menu::class, MenuItem::class);
+        $this->expectException(MenuNotFoundException::class);
+        $extension->renderEasyMenu($twig, [], 'main');
+    }
+
+    public function testTemplateNotFoundThrowsException(): void
+    {
+        $menu = new Menu();
+        $menu->setCode('main');
+        $menuRepository = $this->createRepository($menu);
+        $itemRepository = $this->createItemRepository(new MenuItem());
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getRepository')->willReturnMap([
+            [Menu::class, $menuRepository],
+            [MenuItem::class, $itemRepository],
+        ]);
+        $twig = new Environment(new ArrayLoader());
+        $extension = new EasyMenuExtension($twig, $em, Menu::class, MenuItem::class);
+        $this->expectException(TemplateNotFoundException::class);
+        $extension->renderEasyMenu($twig, [], 'main');
+    }
+}


### PR DESCRIPTION
## Summary
- add test base for Doctrine ORM
- cover Menu CRUD field configuration
- test menu creation listener behavior
- assert Doctrine mapping listener associations
- validate custom exceptions messages
- add repository configuration tests
- test Twig extension rendering and exceptions
- add fixture for menu entities

## Testing
- `vendor/bin/phpunit -c phpunit.xml.dist tests/EasyMenu --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_68443e4997d4832381740b0aefa8eacf